### PR TITLE
docs: rename EDOT to Elastic OTel Browser for 9.5 rebrand

### DIFF
--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -1,4 +1,4 @@
-project: 'EDOT Browser'
+project: 'Elastic OTel Browser'
 cross_links:
   - apm-agent-android
   - apm-agent-dotnet
@@ -37,9 +37,9 @@ toc:
 
 subs:
   motlp: Elastic Cloud Managed OTLP Endpoint
-  edot: Elastic Distribution of OpenTelemetry
+  edot: Elastic OpenTelemetry
   ecloud:   "Elastic Cloud"
-  edot-cf:   "EDOT Cloud Forwarder"
+  edot-cf:   "Elastic Cloud Forwarder"
   ech:   "Elastic Cloud Hosted"
   serverless-full:   "Elastic Cloud Serverless"
   stack:   "Elastic Stack"

--- a/docs/reference/edot-browser/configuration.md
+++ b/docs/reference/edot-browser/configuration.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Configuration
-description: Configure the Elastic Distribution of OpenTelemetry Browser (EDOT Browser).
+description: Configure the Elastic OTel Browser.
 applies_to:
   stack: ga
   serverless:
@@ -13,19 +13,19 @@ products:
   - id: edot-sdk
 ---
 
-# Configure EDOT Browser
+# Configure Elastic OTel Browser [configure-edot-browser]
 
-This page explains how to configure EDOT Browser, which settings are supported, and what's required to start exporting browser telemetry.
+This page explains how to configure Elastic OTel Browser, which settings are supported, and what's required to start exporting browser telemetry.
 
-EDOT Browser follows OpenTelemetry configuration conventions where possible. Like the upstream OpenTelemetry Browser SDK, it uses explicit configuration at initialization rather than environment variables, which are not available in the browser.
+Elastic OTel Browser follows OpenTelemetry configuration conventions where possible. Like the upstream OpenTelemetry Browser SDK, it uses explicit configuration at initialization rather than environment variables, which are not available in the browser.
 
 ## Configuration model in the browser [configuration-model-in-the-browser]
 
-EDOT Browser runs in your users' browsers. Configuration passed to EDOT Browser is accessible to end users, since browser source code and runtime values are visible. This is why you shouldn't embed secrets such as API keys in browser configuration.
+Elastic OTel Browser runs in your users' browsers. Configuration passed to Elastic OTel Browser is accessible to end users, since browser source code and runtime values are visible. This is why you shouldn't embed secrets such as API keys in browser configuration.
 
 Environment variables exist at build time only: a bundler replaces `process.env.*` with values when bundling, but these values are not available at runtime in the browser. You can provide configuration at build time (bundler-defined constants) or at runtime (options passed to the initialization function).
 
-EDOT Browser does not read `OTEL_*` variables directly. Instead, it accepts configuration values passed explicitly during initialization.
+Elastic OTel Browser does not read `OTEL_*` variables directly. Instead, it accepts configuration values passed explicitly during initialization.
 
 ### Common configuration patterns
 
@@ -38,7 +38,7 @@ The best approach depends on your application architecture and build tooling.
 
 ## Minimal required configuration [minimal-required-configuration]
 
-At a minimum, EDOT Browser requires:
+At a minimum, Elastic OTel Browser requires:
 
 - A service name to identify the frontend application.
 - An export endpoint that points to a reverse proxy.
@@ -87,7 +87,7 @@ For details on reverse proxy and authorization, refer to [OpenTelemetry for Real
 
 ## Logging and diagnostics [logging-and-diagnostics]
 
-EDOT Browser uses the OpenTelemetry diagnostic logger.
+Elastic OTel Browser uses the OpenTelemetry diagnostic logger.
 
 To troubleshoot setup issues, increase the log level when calling `startBrowserSdk`:
 
@@ -101,15 +101,15 @@ startBrowserSdk({
 });
 ```
 
-Diagnostic logs are written to the browser console. For more information on using debug logging to troubleshoot issues, refer to [Enable debug logging for EDOT SDKs](docs-content://troubleshoot/ingest/opentelemetry/edot-sdks/enable-debug-logging.md) and [Enable debug logging](docs-content://troubleshoot/ingest/opentelemetry/edot-collector/enable-debug-logging.md) (Collector).
+Diagnostic logs are written to the browser console. For more information on using debug logging to troubleshoot issues, refer to [Enable debug logging for Elastic OTel SDKs](docs-content://troubleshoot/ingest/opentelemetry/edot-sdks/enable-debug-logging.md) and [Enable debug logging](docs-content://troubleshoot/ingest/opentelemetry/edot-collector/enable-debug-logging.md) (Collector).
 
-## EDOT configuration details
+## Elastic OTel configuration details [edot-configuration-details]
 
-This section provides additional details about configuration settings that require further explanation or behave differently in EDOT Browser compared to OpenTelemetry JS.
+This section provides additional details about configuration settings that require further explanation or behave differently in Elastic OTel Browser compared to OpenTelemetry JS.
 
 ### `instrumentations` details [otel_browser_instrumentations-details]
 
-An object whose keys are the scope names of the available instrumentations in EDOT and whose values are the corresponding configuration objects.
+An object whose keys are the scope names of the available instrumentations in Elastic OTel Browser and whose values are the corresponding configuration objects.
 
 The following keys are supported:
 
@@ -128,4 +128,4 @@ The following keys are supported:
 - Refer to [Install the agent](install-agent.md) and [Proxy and CORS](proxy-cors.md) for installation and proxy configuration.
 - Refer to [Metrics, traces, and logs](telemetry.md) for what each signal emits and limitations.
 - Review [Supported technologies](supported-technologies.md) for browser and instrumentation support.
-- Refer to [Troubleshooting](troubleshooting.md) for EDOT Browser–specific issues, or [OpenTelemetry ingest troubleshooting](docs-content://troubleshoot/ingest/opentelemetry/index.md) for general OTLP ingest issues.
+- Refer to [Troubleshooting](troubleshooting.md) for Elastic OTel Browser–specific issues, or [OpenTelemetry ingest troubleshooting](docs-content://troubleshoot/ingest/opentelemetry/index.md) for general OTLP ingest issues.

--- a/docs/reference/edot-browser/index.md
+++ b/docs/reference/edot-browser/index.md
@@ -1,6 +1,6 @@
 ---
-navigation_title: EDOT Browser
-description: Overview of the Elastic Distribution of OpenTelemetry Browser (EDOT Browser).
+navigation_title: Elastic OTel Browser
+description: Overview of the Elastic OTel Browser.
 type: overview
 applies_to:
   stack: ga
@@ -14,17 +14,17 @@ products:
   - id: edot-sdk
 ---
 
-# {{edot}} Browser
+# {{edot}} Browser [elastic-distribution-of-opentelemetry-browser]
 
-EDOT Browser is Elastic’s distribution of the OpenTelemetry Browser SDK. It provides a bundled, opinionated setup for collecting traces, metrics, and logs from real user interactions in web applications and exporting that data to {{product.observability}} using the OpenTelemetry Protocol (OTLP).
+Elastic OTel Browser is Elastic’s distribution of the OpenTelemetry Browser SDK. It provides a bundled, opinionated setup for collecting traces, metrics, and logs from real user interactions in web applications and exporting that data to {{product.observability}} using the OpenTelemetry Protocol (OTLP).
 
 :::{important}
-EDOT Browser is released as a tech preview. The stack and serverless products referred to in this doc are GA and compatible with EDOT Browser.
+Elastic OTel Browser is released as a tech preview. The stack and serverless products referred to in this doc are GA and compatible with Elastic OTel Browser.
 :::
 
-EDOT Browser is intended for Real User Monitoring (RUM) use cases, where telemetry is collected directly from users’ browsers to understand frontend performance, user interactions, and end-to-end request flows between frontend and backend services. It is based on OpenTelemetry standards and aims to align with contrib OpenTelemetry behavior.
+Elastic OTel Browser is intended for Real User Monitoring (RUM) use cases, where telemetry is collected directly from users’ browsers to understand frontend performance, user interactions, and end-to-end request flows between frontend and backend services. It is based on OpenTelemetry standards and aims to align with contrib OpenTelemetry behavior.
 
-EDOT Browser collects the following signals:
+Elastic OTel Browser collects the following signals:
 
 - **Traces**: For distributed tracing and frontend-to-backend correlation
 - **Metrics**: Browser-side performance and runtime metrics
@@ -34,7 +34,7 @@ For what each signal includes, known limitations, and what is not yet supported,
 
 ## Features [features]
 
-In addition to the features provided by OpenTelemetry Browser, EDOT Browser includes the following:
+In addition to the features provided by OpenTelemetry Browser, Elastic OTel Browser includes the following:
 
 * A single package that bundles multiple OpenTelemetry dependencies, so you can install and update one package for most use cases. This is similar to the `@opentelemetry/auto-instrumentations-web` package.
 * Improvements and bug fixes contributed by Elastic, available before they are released in contrib OpenTelemetry repositories.
@@ -43,38 +43,38 @@ In addition to the features provided by OpenTelemetry Browser, EDOT Browser incl
 
 ## How it works [how-it-works]
 
-EDOT Browser runs in the user's browser as part of your web application. When initialized, it instruments the page and captures telemetry such as document load, user interactions, network requests, and Core Web Vitals. For a full list of what is collected, refer to [Supported technologies](supported-technologies.md).
+Elastic OTel Browser runs in the user's browser as part of your web application. When initialized, it instruments the page and captures telemetry such as document load, user interactions, network requests, and Core Web Vitals. For a full list of what is collected, refer to [Supported technologies](supported-technologies.md).
 
 Data is exported using the OpenTelemetry Protocol (OTLP) over HTTP to an endpoint you configure. Because the SDK runs in the browser, it is recommended to avoid holding credentials there. The recommended approach is to place a reverse proxy that adds API keys or other auth headers before sending data to {{product.observability}} or an OpenTelemetry Collector. For details, refer to [Proxy and CORS configuration](proxy-cors.md).
 
 In {{product.observability}}, you see `external.http` spans for browser fetch and XHR requests, user interaction spans (such as click, submit) that group related frontend and backend activity, and end-to-end traces from the browser to your backend in Discover and Service Maps. For details, refer to [What to expect in {{kib}}](setup.md#what-to-expect-in-kibana) in the setup guide.
 
 :::{note}
-Avoid using EDOT Browser alongside any other {{product.apm}} or RUM agent (including classic Elastic {{product.apm}} browser agents). Running multiple agents can cause conflicting instrumentation, duplicate telemetry, or unexpected behavior.
+Avoid using Elastic OTel Browser alongside any other {{product.apm}} or RUM agent (including classic Elastic {{product.apm}} browser agents). Running multiple agents can cause conflicting instrumentation, duplicate telemetry, or unexpected behavior.
 :::
 
 ## Browser telemetry and authentication [browser-telemetry-and-authentication]
 
-Because EDOT Browser runs in the user’s browser, it cannot safely embed authentication credentials such as API keys. You can export telemetry directly to an OTLP endpoint if you set the appropriate headers (for example `Authorization`). For security, Elastic recommends placing a reverse proxy between the browser and your OTLP endpoint ({{ecloud}} Managed OTLP or an EDOT Collector). A reverse proxy is recommended for the following reasons:
+Because Elastic OTel Browser runs in the user’s browser, it cannot safely embed authentication credentials such as API keys. You can export telemetry directly to an OTLP endpoint if you set the appropriate headers (for example `Authorization`). For security, Elastic recommends placing a reverse proxy between the browser and your OTLP endpoint ({{ecloud}} Managed OTLP or an {{product.elastic-agent}}). A reverse proxy is recommended for the following reasons:
 
-- **Authentication**: The EDOT Collector or Managed OTLP endpoint expects an `Authorization` header with an API key. The reverse proxy injects the header so the key stays on the server and isn't exposed.
+- **Authentication**: The {{product.elastic-agent}} or Managed OTLP endpoint expects an `Authorization` header with an API key. The reverse proxy injects the header so the key stays on the server and isn’t exposed.
 - **Cross-origin requests**: Your web application and the OTLP endpoint often have different origins. Browsers enforce Cross-Origin Resource Sharing (CORS), meaning that without the right headers, export requests are blocked. A reverse proxy on the same origin as your app (or configured to allow it) can add the required CORS headers and handle preflight `OPTIONS` requests.
 - **Traffic control**: You can apply rate limiting or other controls at the proxy before traffic reaches the Collector or {{product.observability}}.
 
-For reverse proxy and CORS configuration, refer to [Proxy and CORS](proxy-cors.md). For installation and initialization, refer to [Set up EDOT Browser](setup.md) and [Install the agent](install-agent.md).
+For reverse proxy and CORS configuration, refer to [Proxy and CORS](proxy-cors.md). For installation and initialization, refer to [Set up Elastic OTel Browser](setup.md) and [Install the agent](install-agent.md).
 
 ## Limitations [limitations]
 
-The following capabilities are not currently available in EDOT Browser:
+The following capabilities are not currently available in Elastic OTel Browser:
 
 - Full feature parity with classic Elastic {{product.apm}} browser agents
 - Migration tooling from classic agents
 
 ## Next steps [next-steps]
 
-To get started with EDOT Browser:
+To get started with Elastic OTel Browser:
 
-- Follow the setup instructions in [Set up EDOT Browser](setup.md): [Install the agent](install-agent.md) and [Configure proxy and CORS](proxy-cors.md).
-- Review configuration options in [Configure EDOT Browser](configuration.md).
+- Follow the setup instructions in [Set up Elastic OTel Browser](setup.md): [Install the agent](install-agent.md) and [Configure proxy and CORS](proxy-cors.md).
+- Review configuration options in [Configure Elastic OTel Browser](configuration.md).
 - Refer to [Supported technologies](supported-technologies.md) for details on browsers and instrumentations.
 - If telemetry does not appear, refer to [Troubleshooting](troubleshooting.md).

--- a/docs/reference/edot-browser/install-agent.md
+++ b/docs/reference/edot-browser/install-agent.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Install the agent
-description: Install and initialize the EDOT Browser agent (package or bundle).
+description: Install and initialize the Elastic OTel Browser agent (package or bundle).
 applies_to:
   stack: ga
   serverless:
@@ -15,17 +15,17 @@ products:
 
 # Install the agent
 
-EDOT Browser is available in two distribution formats: a package for applications that use a bundler, and a prebuilt bundle you can load with a script tag.
+Elastic OTel Browser is available in two distribution formats: a package for applications that use a bundler, and a prebuilt bundle you can load with a script tag.
 
 :::{note}
-The contrib instrumentations included in EDOT Browser are experimental. They may introduce breaking changes to configuration or APIs. Because of that, EDOT Browser uses a development version (`0.x`) and increments the minor version when instrumentations introduce breaking changes or when new features are added.
+The contrib instrumentations included in Elastic OTel Browser are experimental. They may introduce breaking changes to configuration or APIs. Because of that, Elastic OTel Browser uses a development version (`0.x`) and increments the minor version when instrumentations introduce breaking changes or when new features are added.
 :::
 
 ## Installation methods [installation-methods]
 
 | Option | Best for | Trade-offs |
 |--------|----------|------------|
-| **Package** | Applications that use a bundler (for example, webpack, esbuild, or Rollup). | Uses your bundler, so EDOT is included in your application bundle, increasing its size. Provides type definitions, so your build step might catch breaking changes at compile time. |
+| **Package** | Applications that use a bundler (for example, webpack, esbuild, or Rollup). | Uses your bundler, so Elastic OTel Browser is included in your application bundle, increasing its size. Provides type definitions, so your build step might catch breaking changes at compile time. |
 | **Bundle** | Applications that don't use a bundler (a single JavaScript file loaded with a `<script>` tag). | Works out of the box with no build step and does not increase your application bundle size. You must manually check for breaking changes in the configuration. |
 
 :::{tip}
@@ -34,7 +34,7 @@ Before installing, consider [configuring a reverse proxy and CORS](proxy-cors.md
 
 ## Install using the package [install-package]
 
-Install EDOT Browser using your package manager:
+Install Elastic OTel Browser using your package manager:
 
 ```bash
 npm install @elastic/opentelemetry-browser
@@ -42,9 +42,9 @@ npm install @elastic/opentelemetry-browser
 
 When you use the package, your bundler includes the SDK and its instrumentations. You can control which instrumentations are enabled using configuration.
 
-After installation, EDOT Browser is available in your codebase and can be initialized when your application starts. Start EDOT Browser before your application code to ensure all relevant APIs are instrumented. Otherwise, your application might create references to APIs before instrumentation is applied, preventing EDOT Browser from capturing activity.
+After installation, Elastic OTel Browser is available in your codebase and can be initialized when your application starts. Start Elastic OTel Browser before your application code to ensure all relevant APIs are instrumented. Otherwise, your application might create references to APIs before instrumentation is applied, preventing Elastic OTel Browser from capturing activity.
 
-Import and start EDOT Browser in your application's entry point:
+Import and start Elastic OTel Browser in your application's entry point:
 
 ```js
 // Other app imports
@@ -75,9 +75,9 @@ The following example shows how to install and initialize the latest version usi
 </script>
 ```
 
-To activate the bundle, add a `<script>` tag and initialize the SDK. EDOT Browser starts synchronously, ensuring that instrumentations are initialized before any activity occurs. This might impact your application's load time.
+To activate the bundle, add a `<script>` tag and initialize the SDK. Elastic OTel Browser starts synchronously, ensuring that instrumentations are initialized before any activity occurs. This might impact your application’s load time.
 
-To avoid blocking other resources, you can load the script asynchronously. In this case, the EDOT Browser bundle does not block resource loading, but it still blocks the browser’s `onload` event.
+To avoid blocking other resources, you can load the script asynchronously. In this case, the Elastic OTel Browser bundle does not block resource loading, but it still blocks the browser’s `onload` event.
 
 ```html
 <script>
@@ -95,12 +95,12 @@ To avoid blocking other resources, you can load the script asynchronously. In th
 </script>
 ```
 :::{note}
-Although this is the recommended approach, be aware of the following limitation: because EDOT Browser is downloaded and initialized asynchronously, distributed tracing doesn't capture requests that occur before the agent is initialized.
+Although this is the recommended approach, be aware of the following limitation: because Elastic OTel Browser is downloaded and initialized asynchronously, distributed tracing doesn't capture requests that occur before the agent is initialized.
 :::
 
-## Initialize EDOT Browser [initialize]
+## Initialize Elastic OTel Browser [initialize]
 
-Initialize EDOT Browser as early as possible in your application lifecycle so it can capture initial page loads, user interactions, and network requests. Call `startBrowserSdk`:
+Initialize Elastic OTel Browser as early as possible in your application lifecycle so it can capture initial page loads, user interactions, and network requests. Call `startBrowserSdk`:
 
 - At the top of your application entry point
 - In a framework-specific bootstrap location (for example, a React root component, Angular `main.ts`, or a Vue plugin)
@@ -121,14 +121,14 @@ At a minimum, configure:
 - `serviceName`: Identifies your frontend application in {{product.observability}}.
 - `otlpEndpoint`: Must point to your reverse proxy (not directly to {{product.observability}}).
 
-For all configuration options, refer to [Configure EDOT Browser](configuration.md).
+For all configuration options, refer to [Configure Elastic OTel Browser](configuration.md).
 
 ## Verify setup [verify]
 
-You have successfully set up EDOT Browser when the SDK loads without errors in the browser console and telemetry flows to your reverse proxy. To confirm data in {{product.observability}}, open {{kib}} and check for your service and traces. For what you see in the UI, refer to [What to expect in {{kib}}](setup.md#what-to-expect-in-kibana) in the setup guide.
+You have successfully set up Elastic OTel Browser when the SDK loads without errors in the browser console and telemetry flows to your reverse proxy. To confirm data in {{product.observability}}, open {{kib}} and check for your service and traces. For what you see in the UI, refer to [What to expect in {{kib}}](setup.md#what-to-expect-in-kibana) in the setup guide.
 
 ## Next steps [next-steps]
 
-- Refer to [Set up EDOT Browser](setup.md) for an overview and what to expect in {{kib}}.
-- Refer to [Configure EDOT Browser](configuration.md) to customize behavior and defaults.
+- Refer to [Set up Elastic OTel Browser](setup.md) for an overview and what to expect in {{kib}}.
+- Refer to [Configure Elastic OTel Browser](configuration.md) to customize behavior and defaults.
 - Review [Supported technologies](supported-technologies.md) for browsers and instrumentations.

--- a/docs/reference/edot-browser/proxy-cors.md
+++ b/docs/reference/edot-browser/proxy-cors.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Proxy and CORS
-description: Configure a reverse proxy and CORS for EDOT Browser telemetry export.
+description: Configure a reverse proxy and CORS for Elastic OTel Browser telemetry export.
 applies_to:
   stack: ga
   serverless:
@@ -15,7 +15,7 @@ products:
 
 # Proxy and CORS configuration
 
-EDOT Browser exports telemetry from the user's browser to an OTLP endpoint. You can send data directly to an OTLP endpoint if you set the appropriate headers (for example `Authorization`). For security, Elastic recommends placing a reverse proxy in front of your OTLP endpoint and configuring it for authentication and [Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS) so that credentials are not exposed in the browser.
+Elastic OTel Browser exports telemetry from the user's browser to an OTLP endpoint. You can send data directly to an OTLP endpoint if you set the appropriate headers (for example `Authorization`). For security, Elastic recommends placing a reverse proxy in front of your OTLP endpoint and configuring it for authentication and [Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS) so that credentials are not exposed in the browser.
 
 :::{warning}
 Do not send telemetry directly from the browser to {{product.observability}} with an API key in client-side code. Any credentials in browser code are visible to end users and can be misused.
@@ -25,7 +25,7 @@ Do not send telemetry directly from the browser to {{product.observability}} wit
 
 A reverse proxy in front of the OTLP endpoint is recommended for these reasons:
 
-- Authentication: The EDOT Collector or {{ecloud}} Managed OTLP endpoint expects an `Authorization` header with an API key. The reverse proxy injects the header so the key stays on the server and is not exposed to the browser.
+- Authentication: The {{product.elastic-agent}} or {{ecloud}} Managed OTLP endpoint expects an `Authorization` header with an API key. The reverse proxy injects the header so the key stays on the server and is not exposed to the browser.
 - Cross-origin requests: Your web application and the OTLP endpoint often have different origins. Browsers enforce CORS, so without the right headers, export requests are blocked. A reverse proxy on the same origin as your app (or configured to allow it) can add the required CORS headers and handle preflight `OPTIONS` requests.
 - Traffic control: You can apply rate limiting or other controls at the proxy before traffic reaches the Collector or {{product.observability}}.
 
@@ -45,7 +45,7 @@ When your web application and the export endpoint have different origins, the br
 
 ## Example: NGINX reverse proxy [example-nginx]
 
-The following example forwards telemetry from `webapp.example.com` to an EDOT Collector at `collector.example.com`, injects the required `Authorization` header, and handles CORS preflight:
+The following example forwards telemetry from `webapp.example.com` to an {{product.elastic-agent}} at `collector.example.com`, injects the required `Authorization` header, and handles CORS preflight:
 
 ```nginx
 server {
@@ -80,5 +80,5 @@ server {
 
 ## Next steps [next-steps]
 
-- [Install the agent](install-agent.md) and initialize EDOT Browser in your application.
-- Refer to [Configure EDOT Browser](configuration.md) for initialization options.
+- [Install the agent](install-agent.md) and initialize Elastic OTel Browser in your application.
+- Refer to [Configure Elastic OTel Browser](configuration.md) for initialization options.

--- a/docs/reference/edot-browser/setup.md
+++ b/docs/reference/edot-browser/setup.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Setup
-description: Set up the Elastic Distribution of OpenTelemetry Browser (EDOT Browser).
+description: Set up the Elastic OTel Browser.
 applies_to:
   stack: ga
   serverless:
@@ -13,36 +13,36 @@ products:
   - id: edot-sdk
 ---
 
-# Set up EDOT Browser
+# Set up Elastic OTel Browser [set-up-edot-browser]
 
-This guide shows you how to set up the {{edot}} Browser (EDOT Browser) in a web application and export browser telemetry to {{product.observability}}.
+This guide shows you how to set up the {{edot}} Browser in a web application and export browser telemetry to {{product.observability}}.
 
-EDOT Browser runs directly in users' browsers. To send data securely without exposing secrets, use a reverse proxy. When your OTLP endpoint is available ({{ecloud}} managed OTLP or an EDOT Collector), do the following:
+Elastic OTel Browser runs directly in users' browsers. To send data securely without exposing secrets, use a reverse proxy. When your OTLP endpoint is available ({{ecloud}} managed OTLP or an {{product.elastic-agent}}), do the following:
 
-- [Install the agent](install-agent.md): Add EDOT Browser to your application (package or bundle) and initialize it.
+- [Install the agent](install-agent.md): Add Elastic OTel Browser to your application (package or bundle) and initialize it.
 - [Configure proxy and CORS](proxy-cors.md): Set up a reverse proxy in front of your OTLP endpoint and configure CORS so the browser can export telemetry securely.
 
 :::{note}
-Do not run EDOT Browser alongside another {{product.apm}} or RUM agent (including classic Elastic {{product.apm}} browser agents). Multiple agents can cause conflicting instrumentation, duplicate telemetry, or unexpected behavior.
+Do not run Elastic OTel Browser alongside another {{product.apm}} or RUM agent (including classic Elastic {{product.apm}} browser agents). Multiple agents can cause conflicting instrumentation, duplicate telemetry, or unexpected behavior.
 :::
 
 ## Prerequisites [prerequisites]
 
-Before you set up EDOT Browser, you need:
+Before you set up Elastic OTel Browser, you need:
 
 - An {{product.observability}} deployment ({{ecloud}} or self-managed)
-- An OTLP ingest endpoint ({{ecloud}} Managed OTLP or an EDOT Collector)
+- An OTLP ingest endpoint ({{ecloud}} Managed OTLP or an {{product.elastic-agent}})
 
 ## How browser telemetry is exported [how-browser-telemetry-is-exported]
 
-EDOT Browser exports telemetry using the OpenTelemetry Protocol (OTLP) over HTTP. Data flows as follows (assuming you set up the proxy as recommended):
+Elastic OTel Browser exports telemetry using the OpenTelemetry Protocol (OTLP) over HTTP. Data flows as follows (assuming you set up the proxy as recommended):
 
 ```mermaid
 flowchart LR
-    A["Browser<br/>(EDOT Browser)"]
+    A["Browser<br/>(Elastic OTel Browser)"]
     B["Reverse Proxy"]
     C["Elastic Cloud<br/>Managed OTLP Endpoint"]
-    D["EDOT Collector"]
+    D["Elastic Agent"]
     E["Elastic<br/>Observability"]
     A --> B
     B --> C
@@ -51,11 +51,11 @@ flowchart LR
     D --> E
 ```
 
-The browser sends OTLP data to the reverse proxy endpoint that you configure. The reverse proxy then forwards data either to the {{ecloud}} Managed OTLP endpoint or to an EDOT Collector, depending on your chosen ingest path.
+The browser sends OTLP data to the reverse proxy endpoint that you configure. The reverse proxy then forwards data either to the {{ecloud}} Managed OTLP endpoint or to an {{product.elastic-agent}}, depending on your chosen ingest path.
 
 ## What to expect in {{kib}} [what-to-expect-in-kibana]
 
-After EDOT Browser is sending telemetry to {{product.observability}}, your browser app surfaces in the following {{kib}} experiences:
+After Elastic OTel Browser is sending telemetry to {{product.observability}}, your browser app surfaces in the following {{kib}} experiences:
 
 - **{{product.apm}} Service Inventory**: Your browser app appears as a service.
 - **{{product.apm}} trace view**: Distributed traces including browser spans are visible.
@@ -63,24 +63,24 @@ After EDOT Browser is sending telemetry to {{product.observability}}, your brows
 - **Discover**: Traces, metrics, and logs (if emitted by your application) are indexed and queryable.
 
   :::{note}
-  Logs are only present in **Discover** if your application uses the OpenTelemetry Logs API to emit them. Refer to [Logs](telemetry.md#logs) for more information on what EDOT Browser emits and how to configure log export.
+  Logs are only present in **Discover** if your application uses the OpenTelemetry Logs API to emit them. Refer to [Logs](telemetry.md#logs) for more information on what Elastic OTel Browser emits and how to configure log export.
   :::
 
-The **User Experience** app currently shows only data from classic Elastic {{product.apm}} Browser agents and does not display EDOT Browser data. For RUM-style dashboards compatible with EDOT Browser, install the [RUM OpenTelemetry Assets](https://github.com/elastic/integrations/tree/main/packages/otel_rum_dashboards) integration from the {{kib}} Integrations catalog. The integration is currently in preview, requires {{kib}} 9.2.1 or later, and on the Integrations page you must turn on **Display beta integrations** to find it.
+The **User Experience** app currently shows only data from classic Elastic {{product.apm}} Browser agents and does not display Elastic OTel Browser data. For RUM-style dashboards compatible with Elastic OTel Browser, install the [RUM OpenTelemetry Assets](https://github.com/elastic/integrations/tree/main/packages/otel_rum_dashboards) integration from the {{kib}} Integrations catalog. The integration is currently in preview, requires {{kib}} 9.2.1 or later, and on the Integrations page you must turn on **Display beta integrations** to find it.
 
 ### Document load spans [document-load-spans]
 
-EDOT Browser measures how long it takes a user's browser to fully load the initial HTML document served by your web server by creating document load spans. It also generates spans to measure the download time of additional resources (such as JavaScript, CSS, fonts, and images) referenced by the initial document.
+Elastic OTel Browser measures how long it takes a user's browser to fully load the initial HTML document served by your web server by creating document load spans. It also generates spans to measure the download time of additional resources (such as JavaScript, CSS, fonts, and images) referenced by the initial document.
 
 In the trace view, the `documentLoad` span appears as the root span, with resource spans as its children.
 
 ### Spans from browser fetch and XHR [spans-from-fetch-xhr]
 
-Outgoing HTTP requests made with the browser `fetch` API or `XMLHttpRequest` are captured as `external.http` spans. Each request to your backend APIs or third-party domains appears as an `external.http` span with attributes such as URL, HTTP method, and status code. These spans represent the client-side portion of the request (time in the browser) and, when your backend is instrumented with EDOT, link to the corresponding server-side trace using the trace context (trace ID and span ID) propagated in HTTP headers. In the trace view, you see the browser's `external.http` span as part of the same trace as the backend service spans when propagation is correctly configured.
+Outgoing HTTP requests made with the browser `fetch` API or `XMLHttpRequest` are captured as `external.http` spans. Each request to your backend APIs or third-party domains appears as an `external.http` span with attributes such as URL, HTTP method, and status code. These spans represent the client-side portion of the request (time in the browser) and, when your backend is instrumented with {{edot}}, link to the corresponding server-side trace using the trace context (trace ID and span ID) propagated in HTTP headers. In the trace view, you see the browser's `external.http` span as part of the same trace as the backend service spans when propagation is correctly configured.
 
 ### User interaction spans and grouping [user-interaction-spans]
 
-EDOT Browser creates user interaction spans for events such as "click" and "submit". These spans represent the user action that triggered subsequent work (for example, a button click that leads to a `fetch` call). In {{kib}}, user interaction spans are used to group related spans: the interaction span is the logical parent or anchor for the cascade of operations that follow (for example, `external.http` requests and any child spans). When you analyze a trace, look for the user interaction span (for example, `userinteraction` or similar) to understand which click or submit caused the associated network and backend activity. This grouping makes it easier to attribute frontend and backend work to specific user actions.
+Elastic OTel Browser creates user interaction spans for events such as "click" and "submit". These spans represent the user action that triggered subsequent work (for example, a button click that leads to a `fetch` call). In {{kib}}, user interaction spans are used to group related spans: the interaction span is the logical parent or anchor for the cascade of operations that follow (for example, `external.http` requests and any child spans). When you analyze a trace, look for the user interaction span (for example, `userinteraction` or similar) to understand which click or submit caused the associated network and backend activity. This grouping makes it easier to attribute frontend and backend work to specific user actions.
 
 ### End-to-end trace propagation [end-to-end-trace-propagation]
 
@@ -97,7 +97,7 @@ If trace context is not propagated, browser and backend spans appear as separate
 After completing setup:
 
 - Refer to [Install the agent](install-agent.md) and [Proxy and CORS](proxy-cors.md) for installation and proxy configuration.
-- Refer to [Configure EDOT Browser](configuration.md) to customize behavior and defaults.
+- Refer to [Configure Elastic OTel Browser](configuration.md) to customize behavior and defaults.
 - Refer to [Metrics, traces, and logs](telemetry.md) for what is emitted for each signal and known limitations.
 - Review [Supported technologies](supported-technologies.md) for information about browsers, bundlers, and instrumentations.
 - If telemetry doesn't appear, refer to [Troubleshooting](troubleshooting.md).

--- a/docs/reference/edot-browser/supported-technologies.md
+++ b/docs/reference/edot-browser/supported-technologies.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Supported technologies
-description: Supported browsers and instrumentations in EDOT Browser.
+description: Supported browsers and instrumentations in Elastic OTel Browser.
 applies_to:
   stack: ga
   serverless:
@@ -28,7 +28,7 @@ At a minimum, the runtime environment must support:
 
 ### Supported browsers [supported-browsers]
 
-EDOT Browser is designed to run in modern evergreen browsers that meet these requirements. 
+Elastic OTel Browser is designed to run in modern evergreen browsers that meet these requirements. 
 
 | Browser | Supported versions |
 |----------|--------------------|
@@ -41,11 +41,11 @@ EDOT Browser is designed to run in modern evergreen browsers that meet these req
 Internet Explorer is not supported.
 :::
 
-If your application targets older browsers, you might need to downlevel the code with a bundler and provide polyfills. EDOT Browser doesn't include built-in polyfills.
+If your application targets older browsers, you might need to downlevel the code with a bundler and provide polyfills. Elastic OTel Browser doesn't include built-in polyfills.
 
 ## Bundlers [bundlers]
 
-When you install EDOT Browser as a package (refer to [Install the agent](install-agent.md)), you build your application with a JavaScript bundler. The following bundlers are supported:
+When you install Elastic OTel Browser as a package (refer to [Install the agent](install-agent.md)), you build your application with a JavaScript bundler. The following bundlers are supported:
 
 | Bundler   | Notes |
 |-----------|-------|
@@ -66,7 +66,7 @@ Usage of `@elastic/opentelemetry-browser` in TypeScript code requires:
 
 ## Included instrumentations [included-instrumentations]
 
-EDOT Browser bundles a curated set of OpenTelemetry JS instrumentations suitable for browser environments. This list is being reviewed and might change in future releases.
+Elastic OTel Browser bundles a curated set of OpenTelemetry JS instrumentations suitable for browser environments. This list is being reviewed and might change in future releases.
 
 The following instrumentations are included and turned on by default. You can turn off any of them using `instrumentations` by setting `{ enabled: false }` for the corresponding key when calling `startBrowserSdk`:
 
@@ -82,7 +82,7 @@ The following instrumentations are included and turned on by default. You can tu
 
 ### Default behavior
 
-By default, EDOT Browser:
+By default, Elastic OTel Browser:
 
 - Initializes tracing
 - Registers included instrumentations
@@ -108,7 +108,7 @@ For capabilities that are not yet available and per-signal limitations (metrics,
 
 ## Next steps [next-steps]
 
-- Refer to [Set up EDOT Browser](setup.md) and [Install the agent](install-agent.md) to get started.
+- Refer to [Set up Elastic OTel Browser](setup.md) and [Install the agent](install-agent.md) to get started.
 - Refer to [Metrics, traces, and logs](telemetry.md) for what is emitted per signal and what is not yet supported.
 - Review [Configuration](configuration.md) to customize behavior.
-- Refer to [Known limitations](#known-limitations) above, [Troubleshooting](troubleshooting.md) for EDOT Browser–specific guidance, or [OpenTelemetry ingest troubleshooting](docs-content://troubleshoot/ingest/opentelemetry/index.md) for general OTLP ingest issues.
+- Refer to [Known limitations](#known-limitations) above, [Troubleshooting](troubleshooting.md) for Elastic OTel Browser–specific guidance, or [OpenTelemetry ingest troubleshooting](docs-content://troubleshoot/ingest/opentelemetry/index.md) for general OTLP ingest issues.

--- a/docs/reference/edot-browser/telemetry.md
+++ b/docs/reference/edot-browser/telemetry.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Metrics, traces, and logs
-description: What EDOT Browser emits for each telemetry signal and known limitations.
+description: What Elastic OTel Browser emits for each telemetry signal and known limitations.
 applies_to:
   stack: ga
   serverless:
@@ -15,13 +15,13 @@ products:
 
 # Metrics, traces, and logs
 
-EDOT Browser can export all three OpenTelemetry signals (metrics, traces, and logs) to {{product.observability}} using OTLP.
+Elastic OTel Browser can export all three OpenTelemetry signals (metrics, traces, and logs) to {{product.observability}} using OTLP.
 
 ## Metrics [metrics]
 
-### What EDOT Browser currently emits [metrics-what-is-emitted]
+### What Elastic OTel Browser currently emits [metrics-what-is-emitted]
 
-EDOT Browser configures the OpenTelemetry MeterProvider and exports metrics over OTLP to the `/v1/metrics` path. Your application can create meters and instruments (counters, histograms, and so on) using the OpenTelemetry Metrics API. EDOT Browser exports those metrics along with any SDK-provided ones.
+Elastic OTel Browser configures the OpenTelemetry MeterProvider and exports metrics over OTLP to the `/v1/metrics` path. Your application can create meters and instruments (counters, histograms, and so on) using the OpenTelemetry Metrics API. Elastic OTel Browser exports those metrics along with any SDK-provided ones.
 
 Ensure your reverse proxy and OTLP endpoint accept the `/v1/metrics` path.
 
@@ -36,7 +36,7 @@ Ensure your reverse proxy and OTLP endpoint accept the `/v1/metrics` path.
 
 ### Context Manager [traces-context-manager]
 
-In certain scenarios, a trace might occur asynchronously. For instance, a user interaction that initiates an HTTP request to a downstream service and subsequently updates the User Interface with the service response. To maintain context across these asynchronous functions, EDOT incorporates a ContextManager that patches several asynchronous browser APIs, including:
+In certain scenarios, a trace might occur asynchronously. For instance, a user interaction that initiates an HTTP request to a downstream service and subsequently updates the User Interface with the service response. To maintain context across these asynchronous functions, Elastic OTel Browser incorporates a ContextManager that patches several asynchronous browser APIs, including:
 
 - setTimeout and setImmediate
 - Promise methods: then, catch, and finally
@@ -44,9 +44,9 @@ In certain scenarios, a trace might occur asynchronously. For instance, a user i
 
 This mechanism ensures that when these asynchronous operations execute, they do so within the same context that was active at the time of their scheduling. Consequently, distributed tracing and context values (such as trace IDs and spans) are accurately preserved across asynchronous boundaries in web applications.
 
-### What EDOT Browser currently emits [traces-what-is-emitted]
+### What Elastic OTel Browser currently emits [traces-what-is-emitted]
 
-EDOT Browser initializes tracing and registers instrumentations that produce spans:
+Elastic OTel Browser initializes tracing and registers instrumentations that produce spans:
 
 - Spans for the initial document load and related navigation timing (document load instrumentation is turned on by default).
 - Each outgoing request using `fetch` or `XMLHttpRequest` is captured as an `external.http` span with attributes such as URL, HTTP method, and status code. These spans represent the client-side portion of the request.
@@ -71,13 +71,13 @@ Full feature parity with classic Elastic {{product.apm}} RUM agents for tracing 
 
 ## Logs [logs]
 
-### What EDOT Browser currently emits [logs-what-is-emitted]
+### What Elastic OTel Browser currently emits [logs-what-is-emitted]
 
-EDOT Browser configures the LoggerProvider automatically, so you can use the OpenTelemetry Logs API directly from your application code without any additional setup. However, no logs are emitted automatically — your application must explicitly create and emit log records for any log data to be sent.
+Elastic OTel Browser configures the LoggerProvider automatically, so you can use the OpenTelemetry Logs API directly from your application code without any additional setup. However, no logs are emitted automatically — your application must explicitly create and emit log records for any log data to be sent.
 
 When your application emits log records and they are exported over OTLP:
 
-- **Application logs**: Your application code can obtain a logger from the OpenTelemetry API and emit log records (severity, body, attributes). EDOT Browser exports these records to your configured endpoint on the `/v1/logs` path.
+- **Application logs**: Your application code can obtain a logger from the OpenTelemetry API and emit log records (severity, body, attributes). Elastic OTel Browser exports these records to your configured endpoint on the `/v1/logs` path.
 - **Resource and context**: Log records are associated with the same resource (for example service name) and can optionally be linked to the active trace context, so you can correlate logs with traces in {{product.observability}}.
 
 There is no requirement to use logs. If your application does not create log records, no log data is sent.
@@ -89,11 +89,11 @@ There is no requirement to use logs. If your application does not create log rec
 - Logs that are not exported before the user navigates away or closes the tab might be lost unless the SDK supports a reliable flush (for example on `beforeunload`). Be aware that some log data might not reach the backend in edge cases.
 
 :::{note}
-Automatic capture of `console` methods (for example `console.log`, `console.error`) is not provided by EDOT Browser. To send logs to {{product.observability}}, you must use the OpenTelemetry Logs API from your application code. Automatic console instrumentation might be considered in the future.
+Automatic capture of `console` methods (for example `console.log`, `console.error`) is not provided by Elastic OTel Browser. To send logs to {{product.observability}}, you must use the OpenTelemetry Logs API from your application code. Automatic console instrumentation might be considered in the future.
 :::
 
 ## Next steps [next-steps]
 
-- Refer to [Set up EDOT Browser](setup.md), [Install the agent](install-agent.md), and [Proxy and CORS](proxy-cors.md) for installation and export configuration.
+- Refer to [Set up Elastic OTel Browser](setup.md), [Install the agent](install-agent.md), and [Proxy and CORS](proxy-cors.md) for installation and export configuration.
 - Refer to [What to expect in {{kib}}](setup.md#what-to-expect-in-kibana) for how traces appear in the Observability app.
-- Refer to [Supported technologies](supported-technologies.md) for included instrumentations and [Configure EDOT Browser](configuration.md) for turning signals and instrumentations on or off.
+- Refer to [Supported technologies](supported-technologies.md) for included instrumentations and [Configure Elastic OTel Browser](configuration.md) for turning signals and instrumentations on or off.

--- a/docs/reference/edot-browser/troubleshooting.md
+++ b/docs/reference/edot-browser/troubleshooting.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Troubleshooting
-description: Troubleshoot EDOT Browser telemetry export and common issues.
+description: Troubleshoot Elastic OTel Browser telemetry export and common issues.
 applies_to:
   stack: ga
   serverless:
@@ -13,13 +13,13 @@ products:
   - id: edot-sdk
 ---
 
-# Troubleshooting EDOT Browser
+# Troubleshooting Elastic OTel Browser [troubleshooting-edot-browser]
 
 If telemetry doesn't appear in {{product.observability}}, try the following:
 
 - Confirm the `otlpEndpoint` option points to your reverse proxy (not directly to {{product.observability}}) and doesn't include signal paths like `/v1/traces`.
 - Check the browser console for network errors or OpenTelemetry-related messages. Cross-Origin Resource Sharing (CORS) errors often mean the reverse proxy is not sending the right `Access-Control-Allow-Origin` or preflight response.
-- Ensure the reverse proxy can reach your EDOT Collector or {{ecloud}} Managed OTLP endpoint. To do so, check proxy logs for connection or authorization failures.
+- Ensure the reverse proxy can reach your {{product.elastic-agent}} or {{ecloud}} Managed OTLP endpoint. To do so, check proxy logs for connection or authorization failures.
 - Ensure service name is set and doesn't contain special characters.
 - Set `logLevel` to `debug` or `verbose` in the `startBrowserSdk` options to see detailed export and instrumentation output in the console.
 
@@ -29,11 +29,11 @@ If you use a Content Security Policy, ensure the proxy or OTLP endpoint domain i
 
 If the troubleshooting steps above don't resolve your issue, you can reach the team through the [Elastic discuss forum](https://discuss.elastic.co/tags/c/observability/apm/58/rum) or by opening a GitHub issue. Use the following guidance to choose the right repo:
 
-* **Open an issue in the [EDOT Browser repo](https://github.com/elastic/elastic-otel-rum-js/issues/new)** if the issue relates to:
+* **Open an issue in the [Elastic OTel Browser repo](https://github.com/elastic/elastic-otel-rum-js/issues/new)** if the issue relates to:
 
-  - EDOT Browser-specific behavior or configuration options (for example, `startBrowserSdk`, `otlpEndpoint`)
+  - Elastic OTel Browser-specific behavior or configuration options (for example, `startBrowserSdk`, `otlpEndpoint`)
   - Elastic-specific defaults or signal configuration
-  - EDOT Browser packaging or installation
+  - Elastic OTel Browser packaging or installation
   - Sending data to {{product.observability}}
 
 * **Open an issue in the [OpenTelemetry JS repo](https://github.com/open-telemetry/opentelemetry-js/issues/new) or [JS contrib repo](https://github.com/open-telemetry/opentelemetry-js-contrib/issues/new)** if the issue relates to:
@@ -45,5 +45,5 @@ If the troubleshooting steps above don't resolve your issue, you can reach the t
 ## Next steps [next-steps]
 
 - Refer to [Known limitations](supported-technologies.md#known-limitations) for what is not yet supported.
-- Refer to [Set up EDOT Browser](setup.md), [Install the agent](install-agent.md), and [Proxy and CORS](proxy-cors.md) for installation and proxy configuration.
+- Refer to [Set up Elastic OTel Browser](setup.md), [Install the agent](install-agent.md), and [Proxy and CORS](proxy-cors.md) for installation and proxy configuration.
 - For general OTLP ingest issues, refer to [OpenTelemetry ingest troubleshooting](docs-content://troubleshoot/ingest/opentelemetry/index.md).

--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Breaking changes
-description: Breaking changes for Elastic Distribution of OpenTelemetry Browser.
+description: Breaking changes for Elastic OTel Browser.
 applies_to:
   stack:
   serverless:

--- a/docs/release-notes/deprecations.md
+++ b/docs/release-notes/deprecations.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Deprecations 
-description: Deprecations for Elastic Distribution of OpenTelemetry Browser.
+description: Deprecations for Elastic OTel Browser.
 applies_to:
   stack:
   serverless:

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -1,6 +1,6 @@
 ---
-navigation_title: EDOT Browser
-description: Release notes for Elastic Distribution of OpenTelemetry Browser.
+navigation_title: Elastic OTel Browser
+description: Release notes for Elastic OTel Browser.
 applies_to:
   stack:
   serverless:
@@ -13,9 +13,9 @@ products:
 
 # {{edot}} Browser release notes [edot-browser-release-notes]
 
-Review the changes, fixes, and more in each version of {{edot}} Browser (EDOT Browser).
+Review the changes, fixes, and more in each version of {{edot}} Browser.
 
-To check for breaking changes, see [EDOT Browser Breaking Changes](./breaking-changes.md).
+To check for breaking changes, see [Elastic OTel Browser Breaking Changes](./breaking-changes.md).
 
 To check for security updates, go to [Security announcements for the Elastic stack](https://discuss.elastic.co/c/announcements/security-announcements/31).
 

--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Known issues 
-description: Known issues for Elastic Distribution of OpenTelemetry Browser.
+description: Known issues for Elastic OTel Browser.
 applies_to:
   stack:
   serverless:
@@ -11,6 +11,6 @@ products:
   - id: edot-sdk
 ---
 
-# {{edot}} Browser known issues
+# {{edot}} Browser known issues [elastic-distribution-of-opentelemetry-browser-known-issues]
 
 No known issues.


### PR DESCRIPTION
## Summary

This is a prose-only rebrand of all documentation in preparation for the 9.5 GA release (July 28, 2026).

- **`docs/docset.yml`**: Updated `edot` sub from `Elastic Distribution of OpenTelemetry` → `Elastic OpenTelemetry`; `edot-cf` sub from `EDOT Cloud Forwarder` → `Elastic Cloud Forwarder`; project name to `Elastic OTel Browser`.
- **All `.md` files under `docs/`**: `EDOT Browser` → `Elastic OTel Browser`; `EDOT Collector` → `{{product.elastic-agent}}`; `EDOT SDKs` → `Elastic OTel SDKs`; generic `EDOT` → `{{edot}}` or `Elastic OTel Browser` as appropriate.
- **Mermaid diagram** (`setup.md`): node labels updated to match new naming.
- **Explicit anchors** added to all renamed headings to preserve existing URL slugs.

Machine identifiers are **unchanged**: URL path slugs (`edot-browser/`), `applies_to` product IDs, code block identifiers, env vars, and package names are all preserved. Release note entries for pre-9.5 versions are also preserved.

Held as a draft for coordinated merge on July 28, 2026 with the 9.5 GA release.

## Files touched

13 files changed (110 insertions, 110 deletions — net zero, prose substitutions only):
- `docs/docset.yml`
- `docs/reference/edot-browser/index.md`
- `docs/reference/edot-browser/configuration.md`
- `docs/reference/edot-browser/install-agent.md`
- `docs/reference/edot-browser/proxy-cors.md`
- `docs/reference/edot-browser/setup.md`
- `docs/reference/edot-browser/supported-technologies.md`
- `docs/reference/edot-browser/telemetry.md`
- `docs/reference/edot-browser/troubleshooting.md`
- `docs/release-notes/index.md`
- `docs/release-notes/breaking-changes.md`
- `docs/release-notes/deprecations.md`
- `docs/release-notes/known-issues.md`

## Anchors added to preserve old slugs

| File | Old heading slug |
|------|-----------------|
| `reference/edot-browser/index.md` | `elastic-distribution-of-opentelemetry-browser` |
| `reference/edot-browser/configuration.md` | `configure-edot-browser` |
| `reference/edot-browser/configuration.md` | `edot-configuration-details` |
| `reference/edot-browser/setup.md` | `set-up-edot-browser` |
| `reference/edot-browser/troubleshooting.md` | `troubleshooting-edot-browser` |
| `release-notes/known-issues.md` | `elastic-distribution-of-opentelemetry-browser-known-issues` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)