### PR TITLE
POC: experimental session replay

### DIFF
--- a/packages/opentelemetry-browser/README.md
+++ b/packages/opentelemetry-browser/README.md
@@ -17,3 +17,31 @@ EDOT Browser is very similar to the `@opentelemetry/auto-instrumentations-web` p
 - EDOT Browser, being a [distribution](https://opentelemetry.io/docs/concepts/distributions/) of the OpenTelemetry JS SDK, always adds the [`telemetry.distro.*`](https://opentelemetry.io/docs/specs/semconv/attributes-registry/telemetry/) resource attributes to identify itself.
 
 - EDOT Browser defaults to [`OTEL_SEMCONV_STABILITY_OPT_IN=http`](https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/) such that telemetry from the `@opentelemetry/instrumentation-fetch` and `@opentelemetry/instrumentation-xml-http-request` package will use stable HTTP semantic conventions by default. Upstream OpenTelemetry JS has [a tracking issue for the migration to newer HTTP semantic conventions](https://github.com/open-telemetry/opentelemetry-js/issues/5646) in its instrumentations.
+
+## Experimental: session replay (POC)
+
+> **Experimental / not GA.** Session replay POC — not for production use.
+
+Opt in via `startBrowserSdk({ replay: { enabled: true } })`. When enabled, the SDK dynamically loads [`@rrweb/record`](https://www.npmjs.com/package/@rrweb/record) and exports DOM recording events as OTLP logs with instrumentation scope `elastic-rrweb`.
+
+```js
+import { startBrowserSdk } from '@elastic/opentelemetry-browser';
+
+const sdk = startBrowserSdk({
+  serviceName: 'my-app',
+  otlpEndpoint: 'https://otlp-proxy.example',
+  replay: {
+    enabled: true,
+    samplingRate: 10,
+    errorSamplingRate: 100,
+    privacy: { maskAllInputs: true },
+  },
+});
+
+sdk.pauseReplay();
+sdk.resumeReplay();
+await sdk.forceFlush();
+```
+
+Route collector logs where `instrumentation_scope.name == "elastic-rrweb"` to a dedicated data stream (e.g. `logs-rum.replay-*` with LogsDB). Default script-tag builds keep `@rrweb/record` external; use `elastic-otel-browser-replay.min.js` (or a bundler that resolves the dynamic import) when enabling replay from a `<script>` tag.
+

--- a/packages/opentelemetry-browser/lib/replay.js
+++ b/packages/opentelemetry-browser/lib/replay.js
@@ -1,0 +1,351 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {diag} from '@opentelemetry/api';
+import {SeverityNumber} from '@opentelemetry/api-logs';
+
+const BUCKET_CAPACITY = 100;
+const BUCKET_REFILL_RATE = 10; // tokens/sec
+const MAX_BUFFER_EVENTS = 200;
+const MAX_BUFFER_BYTES = 5 * 1024 * 1024;
+
+/** @type {Map<number, {tokens: number, lastRefill: number}>} */
+let _buckets = new Map();
+let _refillTimer = null;
+
+let _live = false;
+/** @type {any[]} */
+let _buffer = [];
+/** @type {(() => void) | null} */
+let _stopFn = null;
+/** @type {import('@opentelemetry/api-logs').Logger | null} */
+let _replayLogger = null;
+/** @type {any} */
+let _cfg = null;
+/** @type {(() => string | null) | null} */
+let _getSessionId = null;
+/** @type {((cfg?: any, fn?: Function) => boolean) | null} */
+let _checkRotation = null;
+let _active = false;
+let _eventCounter = 0;
+/** @type {(() => void) | null} */
+let _visibilityHandler = null;
+/** @type {(() => void) | null} */
+let _onError = null;
+/** @type {{record: Function, takeFullSnapshot?: Function} | null} */
+let _rrweb = null;
+/** @type {Promise<void> | null} */
+let _startPromise = null;
+
+/**
+ * Starts rrweb recording (loads `@rrweb/record` dynamically).
+ *
+ * @param {{
+ *   samplingRate?: number,
+ *   errorSamplingRate?: number,
+ *   replayLogger: import('@opentelemetry/api-logs').Logger,
+ *   getSessionId: () => string | null,
+ *   checkRotation: (cfg?: any, fn?: Function) => boolean,
+ *   privacy?: object,
+ *   quality?: object,
+ * }} cfg
+ * @returns {Promise<void>}
+ */
+export function startReplay(cfg) {
+    if (_active || _startPromise) {
+        return _startPromise ?? Promise.resolve();
+    }
+
+    _startPromise = _startReplayAsync(cfg).finally(() => {
+        _startPromise = null;
+    });
+    return _startPromise;
+}
+
+/**
+ * @param {any} cfg
+ * @returns {Promise<void>}
+ */
+async function _startReplayAsync(cfg) {
+    _cfg = cfg;
+    _replayLogger = cfg.replayLogger;
+    _getSessionId = cfg.getSessionId;
+    _checkRotation = cfg.checkRotation;
+
+    _live = Math.random() * 100 < (cfg.samplingRate ?? 100);
+
+    if (!_live && (cfg.errorSamplingRate ?? 0) > 0) {
+        _onError = () => _activateFromError();
+        window.addEventListener('error', _onError);
+        window.addEventListener('unhandledrejection', _onError);
+    }
+
+    _refillTimer = setInterval(_refillBuckets, 1000);
+
+    let recordFn;
+    try {
+        const mod = await import('@rrweb/record');
+        recordFn = mod.record;
+        _rrweb = mod;
+    } catch (err) {
+        diag.warn('Replay: failed to load @rrweb/record', err);
+        _cleanupPartialStart();
+        return;
+    }
+
+    const privacyCfg = cfg.privacy ?? {};
+    const qualityCfg = cfg.quality ?? {};
+
+    try {
+        _stopFn = recordFn({
+            emit: _onEvent,
+            maskAllInputs: privacyCfg.maskAllInputs ?? true,
+            maskTextSelector: privacyCfg.maskAllText
+                ? '*'
+                : privacyCfg.maskTextSelector,
+            blockSelector: privacyCfg.blockSelector,
+            blockClass: privacyCfg.blockClass ?? 'rum-block',
+            ignoreClass: privacyCfg.ignoreClass ?? 'rum-ignore',
+            maskInputOptions: privacyCfg.maskInputOptions,
+            maskInputFn: privacyCfg.maskInputFn,
+            inlineStylesheet: qualityCfg.inlineStylesheet ?? true,
+            collectFonts: qualityCfg.collectFonts ?? false,
+            slimDOMOptions: qualityCfg.slimDOM ?? true,
+            recordCanvas: qualityCfg.recordCanvas ?? false,
+            sampling: {
+                mousemove: 50,
+                scroll: 150,
+                input: 'last',
+                canvas: 2,
+            },
+            checkoutEveryNms: 5 * 60 * 1000,
+            errorHandler: (err) => {
+                diag.warn('Replay: rrweb internal error:', err);
+                return true;
+            },
+        });
+        if (typeof _stopFn !== 'function') {
+            diag.warn(
+                'Replay: record() returned non-function — snapshot likely failed'
+            );
+        }
+    } catch (err) {
+        diag.warn('Replay: record() threw:', err);
+        _cleanupPartialStart();
+        return;
+    }
+
+    _active = true;
+
+    _visibilityHandler = () => {
+        if (!document.hidden && _live) {
+            _takeFullSnapshot();
+        }
+    };
+    document.addEventListener('visibilitychange', _visibilityHandler);
+
+    diag.debug('Replay started, live=', _live);
+
+    if (_live) {
+        try {
+            const packEvents = _cfg?.quality?.packEvents ?? false;
+            _replayLogger.emit({
+                body: JSON.stringify({
+                    type: 99,
+                    timestamp: Date.now(),
+                    data: {name: 'replay-started'},
+                }),
+                attributes: {
+                    'elastic.rum.log.type': 'replay',
+                    'rrweb.type': 99,
+                    'rrweb.packed': packEvents ? 1 : 0,
+                    'rr-web.event': 0,
+                    'rr-web.chunk': 1,
+                    'rr-web.total-chunks': 1,
+                    'session.id': _getSessionId?.() ?? '',
+                    'rum.sessionId': _getSessionId?.() ?? '',
+                },
+            });
+        } catch (_) {}
+    }
+}
+
+export function pauseReplay() {
+    _live = false;
+}
+
+export function resumeReplay() {
+    _live = true;
+    _takeFullSnapshot();
+}
+
+export function stopReplay() {
+    if (_stopFn) {
+        try {
+            _stopFn();
+        } catch (_) {}
+        _stopFn = null;
+    }
+    _cleanupPartialStart();
+    _buckets.clear();
+    _buffer = [];
+    _active = false;
+    _rrweb = null;
+    _eventCounter = 0;
+    _live = false;
+    _cfg = null;
+    _replayLogger = null;
+    _getSessionId = null;
+    _checkRotation = null;
+}
+
+function _cleanupPartialStart() {
+    if (_refillTimer) {
+        clearInterval(_refillTimer);
+        _refillTimer = null;
+    }
+    if (_visibilityHandler) {
+        document.removeEventListener('visibilitychange', _visibilityHandler);
+        _visibilityHandler = null;
+    }
+    if (_onError) {
+        window.removeEventListener('error', _onError);
+        window.removeEventListener('unhandledrejection', _onError);
+        _onError = null;
+    }
+}
+
+function _takeFullSnapshot() {
+    try {
+        const take =
+            _rrweb?.record?.takeFullSnapshot ?? _rrweb?.takeFullSnapshot;
+        if (typeof take === 'function') {
+            take.call(_rrweb?.record ?? _rrweb);
+        }
+    } catch (err) {
+        diag.debug('Replay: takeFullSnapshot failed', err);
+    }
+}
+
+function _activateFromError() {
+    if (_live) {
+        return;
+    }
+    if (_onError) {
+        window.removeEventListener('error', _onError);
+        window.removeEventListener('unhandledrejection', _onError);
+        _onError = null;
+    }
+    for (const evt of _buffer) {
+        _emitRecord(evt);
+    }
+    _buffer = [];
+    _live = true;
+    diag.debug('Replay: activated from error sampling');
+}
+
+function _onEvent(event) {
+    if (event.type === 3) {
+        const nodeId = event.data?.id ?? 0;
+        if (!_consumeToken(nodeId)) {
+            return;
+        }
+    }
+
+    if (!_live) {
+        _buffer.push(event);
+        if (_buffer.length > MAX_BUFFER_EVENTS) {
+            _buffer.shift();
+        }
+        let bufBytes = 0;
+        for (const e of _buffer) {
+            try {
+                bufBytes += JSON.stringify(e).length;
+            } catch (_) {}
+        }
+        while (_buffer.length > 1 && bufBytes > MAX_BUFFER_BYTES) {
+            const removed = _buffer.shift();
+            try {
+                bufBytes -= JSON.stringify(removed).length;
+            } catch (_) {}
+        }
+        return;
+    }
+
+    _checkRotation?.({maxMs: 840_000, idleMs: 1_800_000}, (newId) => {
+        diag.debug('Session rotated during replay', newId);
+    });
+
+    _emitRecord(event);
+}
+
+function _emitRecord(event) {
+    if (!_replayLogger) {
+        return;
+    }
+    const sessionId = _getSessionId?.() ?? '';
+    const packEvents = _cfg?.quality?.packEvents ?? false;
+
+    let body;
+    try {
+        body = JSON.stringify(event);
+    } catch (err) {
+        diag.warn('replay: serialise error', err);
+        return;
+    }
+
+    const eventIdx = ++_eventCounter;
+
+    try {
+        _replayLogger.emit({
+            body,
+            severityNumber: SeverityNumber.UNSPECIFIED,
+            attributes: {
+                'session.id': sessionId,
+                'rum.sessionId': sessionId,
+                'rr-web.event': eventIdx,
+                'rr-web.offset': eventIdx,
+                'rr-web.chunk': 1,
+                'rr-web.total-chunks': 1,
+                'rrweb.type': event.type ?? 0,
+                'rrweb.packed': packEvents ? 1 : 0,
+                'page.url': window.location.href,
+                'page.url.path': window.location.pathname,
+                'elastic.rum.log.type': 'replay',
+            },
+        });
+    } catch (err) {
+        diag.warn('replay: emit error', err);
+    }
+}
+
+function _consumeToken(nodeId) {
+    const now = Date.now();
+    let bucket = _buckets.get(nodeId);
+    if (!bucket) {
+        bucket = {tokens: BUCKET_CAPACITY, lastRefill: now};
+        _buckets.set(nodeId, bucket);
+    }
+    if (bucket.tokens > 0) {
+        bucket.tokens--;
+        return true;
+    }
+    return false;
+}
+
+function _refillBuckets() {
+    for (const bucket of _buckets.values()) {
+        bucket.tokens = Math.min(
+            BUCKET_CAPACITY,
+            bucket.tokens + BUCKET_REFILL_RATE
+        );
+    }
+    if (_buckets.size > 500) {
+        const keys = [..._buckets.keys()];
+        for (const k of keys.slice(0, _buckets.size - 500)) {
+            _buckets.delete(k);
+        }
+    }
+}

--- a/packages/opentelemetry-browser/lib/replay.js
+++ b/packages/opentelemetry-browser/lib/replay.js
@@ -34,7 +34,7 @@ let _eventCounter = 0;
 let _visibilityHandler = null;
 /** @type {(() => void) | null} */
 let _onError = null;
-/** @type {{record: Function, takeFullSnapshot?: Function} | null} */
+/** @type {{record: Function & {takeFullSnapshot?: Function}, takeFullSnapshot?: Function} | null} */
 let _rrweb = null;
 /** @type {Promise<void> | null} */
 let _startPromise = null;

--- a/packages/opentelemetry-browser/lib/replay.js
+++ b/packages/opentelemetry-browser/lib/replay.js
@@ -11,6 +11,22 @@ const BUCKET_REFILL_RATE = 10; // tokens/sec
 const MAX_BUFFER_EVENTS = 200;
 const MAX_BUFFER_BYTES = 5 * 1024 * 1024;
 
+// rrweb IncrementalSource values that are safe to rate-limit: high-frequency
+// interaction noise that carries no DOM/CSS state, so dropping a few frames only
+// costs cursor/scroll smoothness. Everything else (mutation, input, stylesheet
+// rule, style declaration, canvas, font, adopted stylesheet, media) mutates the
+// replayed document and must NEVER be dropped — a single dropped structural or
+// style event permanently corrupts every later frame.
+const THROTTLEABLE_SOURCES = new Set([
+    1, // MouseMove
+    2, // MouseInteraction
+    3, // Scroll
+    4, // ViewportResize
+    6, // TouchMove
+    12, // Drag
+    14, // Selection
+]);
+
 // Persist the replay event sequence next to the session id. Each full page
 // navigation reloads this module with a fresh JS context, so an in-memory
 // counter would restart at 0 on every page and `rr-web.event` would no longer
@@ -42,6 +58,17 @@ let _eventCounter = 0;
 let _visibilityHandler = null;
 /** @type {(() => void) | null} */
 let _onError = null;
+/** @type {Array<ReturnType<typeof setTimeout>>} */
+let _settleTimers = [];
+/** @type {(() => void) | null} */
+let _settleLoadHandler = null;
+/** @type {ReturnType<typeof setTimeout> | null} */
+let _settleQuietTimer = null;
+/** @type {ReturnType<typeof setTimeout> | null} */
+let _settleMaxTimer = null;
+let _settleQuietMs = 0;
+let _settleDone = false;
+let _settleSawChange = false;
 /** @type {{record: Function & {takeFullSnapshot?: Function}, takeFullSnapshot?: Function} | null} */
 let _rrweb = null;
 /** @type {Promise<void> | null} */
@@ -157,6 +184,24 @@ async function _startReplayAsync(cfg) {
     };
     document.addEventListener('visibilitychange', _visibilityHandler);
 
+    if (qualityCfg.settleSnapshot ?? true) {
+        const fixedDelays =
+            qualityCfg.settleSnapshotDelaysMs ??
+            qualityCfg.settleSnapshotDelayMs;
+        if (fixedDelays != null) {
+            // Escape hatch: explicit, app-tuned snapshot offsets.
+            _scheduleSettleSnapshot(
+                Array.isArray(fixedDelays) ? fixedDelays : [fixedDelays]
+            );
+        } else {
+            // Default: adaptive. Snapshot once the DOM stops changing.
+            _armSettleWatcher(
+                qualityCfg.settleQuietMs ?? 500,
+                qualityCfg.settleMaxWaitMs ?? 5000
+            );
+        }
+    }
+
     diag.debug('Replay started, live=', _live);
 
     if (_live) {
@@ -228,6 +273,25 @@ function _cleanupPartialStart() {
         window.removeEventListener('unhandledrejection', _onError);
         _onError = null;
     }
+    for (const timer of _settleTimers) {
+        clearTimeout(timer);
+    }
+    _settleTimers = [];
+    if (_settleQuietTimer) {
+        clearTimeout(_settleQuietTimer);
+        _settleQuietTimer = null;
+    }
+    if (_settleMaxTimer) {
+        clearTimeout(_settleMaxTimer);
+        _settleMaxTimer = null;
+    }
+    _settleQuietMs = 0;
+    _settleDone = false;
+    _settleSawChange = false;
+    if (_settleLoadHandler) {
+        window.removeEventListener('load', _settleLoadHandler);
+        _settleLoadHandler = null;
+    }
 }
 
 function _takeFullSnapshot() {
@@ -240,6 +304,109 @@ function _takeFullSnapshot() {
     } catch (err) {
         diag.debug('Replay: takeFullSnapshot failed', err);
     }
+}
+
+/**
+ * Re-snapshot once the DOM stops changing after load (framework-agnostic).
+ *
+ * rrweb only inlines the CSS present at snapshot time. Many sites inject styles
+ * via CSSOM (`insertRule`, CSS-in-JS) as components render — after the initial
+ * snapshot — and rrweb's incremental style observers can miss rules whose owner
+ * `<style>` isn't yet in the mirror, leaving replayed content unstyled. Taking a
+ * fresh full snapshot once the page goes quiet re-serialises the DOM and
+ * re-reads every stylesheet's `cssRules`, capturing the fully-rendered page.
+ *
+ * Adaptive by design: the snapshot fires a short "quiet" window after the last
+ * DOM mutation (so async/staged pages are captured once their content lands) and
+ * is capped by a max wait; it is skipped entirely if nothing changed after load.
+ *
+ * @param {number} quietMs quiet window after the last mutation
+ * @param {number} maxWaitMs upper bound measured from page load
+ */
+function _armSettleWatcher(quietMs, maxWaitMs) {
+    _settleQuietMs = quietMs;
+    const start = () => {
+        _bumpSettleQuiet();
+        _settleMaxTimer = setTimeout(() => _fireSettle(), maxWaitMs);
+    };
+    if (document.readyState === 'complete') {
+        start();
+        return;
+    }
+    _settleLoadHandler = () => start();
+    window.addEventListener('load', _settleLoadHandler, {once: true});
+}
+
+/** (Re)arm the quiet-window timer; called on each visually-relevant change. */
+function _bumpSettleQuiet() {
+    if (_settleDone || !_settleQuietMs) {
+        return;
+    }
+    if (_settleQuietTimer) {
+        clearTimeout(_settleQuietTimer);
+    }
+    _settleQuietTimer = setTimeout(() => _fireSettle(), _settleQuietMs);
+}
+
+function _fireSettle() {
+    if (_settleDone) {
+        return;
+    }
+    _settleDone = true;
+    if (_settleQuietTimer) {
+        clearTimeout(_settleQuietTimer);
+        _settleQuietTimer = null;
+    }
+    if (_settleMaxTimer) {
+        clearTimeout(_settleMaxTimer);
+        _settleMaxTimer = null;
+    }
+    // Nothing rendered after the initial snapshot — it already covers the page.
+    if (!_settleSawChange) {
+        return;
+    }
+    const idle =
+        typeof requestIdleCallback === 'function'
+            ? requestIdleCallback
+            : (fn) => setTimeout(fn, 0);
+    idle(() => {
+        if (_active) {
+            _takeFullSnapshot();
+        }
+    });
+}
+
+/**
+ * Escape hatch: take full snapshots at explicit offsets from page load.
+ *
+ * @param {number[]} delaysMs snapshot offsets (ms) measured from page load
+ */
+function _scheduleSettleSnapshot(delaysMs) {
+    const runAfterIdle = () => {
+        // Debounce past the burst of mutations that follow first paint, then
+        // wait for idle so we don't contend with the app's own rendering.
+        const idle =
+            typeof requestIdleCallback === 'function'
+                ? requestIdleCallback
+                : (fn) => setTimeout(fn, 0);
+        for (const delayMs of delaysMs) {
+            const timer = setTimeout(() => {
+                idle(() => {
+                    if (_active) {
+                        _takeFullSnapshot();
+                    }
+                });
+            }, delayMs);
+            _settleTimers.push(timer);
+        }
+    };
+
+    if (document.readyState === 'complete') {
+        runAfterIdle();
+        return;
+    }
+    _settleLoadHandler = () => runAfterIdle();
+    window.addEventListener('load', _settleLoadHandler, {once: true});
 }
 
 function _activateFromError() {
@@ -260,7 +427,20 @@ function _activateFromError() {
 }
 
 function _onEvent(event) {
-    if (event.type === 3) {
+    // Track DOM/CSS activity so the adaptive settle snapshot can fire once the
+    // page goes quiet (source 0 = mutation, 8 = stylesheet rule insert/delete).
+    if (
+        !_settleDone &&
+        _settleQuietMs &&
+        event.type === 3 &&
+        (event.data?.source === 0 || event.data?.source === 8)
+    ) {
+        _settleSawChange = true;
+        _bumpSettleQuiet();
+    }
+
+    // Only throttle interaction noise; never drop structural/style events.
+    if (event.type === 3 && THROTTLEABLE_SOURCES.has(event.data?.source)) {
         const nodeId = event.data?.id ?? 0;
         if (!_consumeToken(nodeId)) {
             return;

--- a/packages/opentelemetry-browser/lib/replay.js
+++ b/packages/opentelemetry-browser/lib/replay.js
@@ -11,6 +11,14 @@ const BUCKET_REFILL_RATE = 10; // tokens/sec
 const MAX_BUFFER_EVENTS = 200;
 const MAX_BUFFER_BYTES = 5 * 1024 * 1024;
 
+// Persist the replay event sequence next to the session id. Each full page
+// navigation reloads this module with a fresh JS context, so an in-memory
+// counter would restart at 0 on every page and `rr-web.event` would no longer
+// be unique/monotonic within a session — collapsing the reassembled stream onto
+// the first page's snapshot. sessionStorage shares the session's lifetime
+// (per-tab, survives reloads), so the sequence continues across navigations.
+const SEQ_KEY = 'elastic.rum.replay.seq';
+
 /** @type {Map<number, {tokens: number, lastRefill: number}>} */
 let _buckets = new Map();
 let _refillTimer = null;
@@ -73,6 +81,9 @@ async function _startReplayAsync(cfg) {
     _replayLogger = cfg.replayLogger;
     _getSessionId = cfg.getSessionId;
     _checkRotation = cfg.checkRotation;
+
+    // Resume the session-wide sequence (0 for a fresh/rotated session).
+    _eventCounter = _loadSeq(_getSessionId?.() ?? '');
 
     _live = Math.random() * 100 < (cfg.samplingRate ?? 100);
 
@@ -151,6 +162,7 @@ async function _startReplayAsync(cfg) {
     if (_live) {
         try {
             const packEvents = _cfg?.quality?.packEvents ?? false;
+            const eventIdx = _nextSeq();
             _replayLogger.emit({
                 body: JSON.stringify({
                     type: 99,
@@ -161,7 +173,8 @@ async function _startReplayAsync(cfg) {
                     'elastic.rum.log.type': 'replay',
                     'rrweb.type': 99,
                     'rrweb.packed': packEvents ? 1 : 0,
-                    'rr-web.event': 0,
+                    'rr-web.event': eventIdx,
+                    'rr-web.offset': eventIdx,
                     'rr-web.chunk': 1,
                     'rr-web.total-chunks': 1,
                     'session.id': _getSessionId?.() ?? '',
@@ -281,6 +294,46 @@ function _onEvent(event) {
     _emitRecord(event);
 }
 
+/**
+ * Next monotonic, session-unique event index. Persisted so it survives full
+ * page navigations within the session (see SEQ_KEY).
+ *
+ * @returns {number}
+ */
+function _nextSeq() {
+    _eventCounter++;
+    _saveSeq(_getSessionId?.() ?? '', _eventCounter);
+    return _eventCounter;
+}
+
+/**
+ * @param {string} sessionId
+ * @returns {number} stored sequence for this session, or 0 if none/rotated
+ */
+function _loadSeq(sessionId) {
+    try {
+        const raw = sessionStorage.getItem(SEQ_KEY);
+        if (!raw) {
+            return 0;
+        }
+        const parsed = JSON.parse(raw);
+        if (parsed && parsed.sid === sessionId && Number.isFinite(parsed.n)) {
+            return parsed.n;
+        }
+    } catch (_) {}
+    return 0;
+}
+
+/**
+ * @param {string} sessionId
+ * @param {number} n
+ */
+function _saveSeq(sessionId, n) {
+    try {
+        sessionStorage.setItem(SEQ_KEY, JSON.stringify({sid: sessionId, n}));
+    } catch (_) {}
+}
+
 function _emitRecord(event) {
     if (!_replayLogger) {
         return;
@@ -296,7 +349,7 @@ function _emitRecord(event) {
         return;
     }
 
-    const eventIdx = ++_eventCounter;
+    const eventIdx = _nextSeq();
 
     try {
         _replayLogger.emit({

--- a/packages/opentelemetry-browser/lib/sdk.js
+++ b/packages/opentelemetry-browser/lib/sdk.js
@@ -162,9 +162,15 @@ export function startBrowserSdk(cfg = {}) {
         return;
     }
 
-    // Detect resource
+    // Session id is independent of Session Replay — stamp it on all signals.
+    /** @type {string} */
+    const sessionId = initSession();
     const resource = detectResource(
-        config.resourceAttributes,
+        {
+            ...config.resourceAttributes,
+            'session.id': sessionId,
+            'rum.sessionId': sessionId,
+        },
         serviceName,
         serviceVersion
     );
@@ -274,8 +280,6 @@ export function startBrowserSdk(cfg = {}) {
     let replayLoggerProvider = null;
     /** @type {Promise<void>} */
     let replayReady = Promise.resolve();
-    /** @type {string | null} */
-    let sessionId = null;
 
     if (replayCfg.enabled) {
         // Elastic Synthetics injects syntheticsRunId. Do not use
@@ -283,8 +287,6 @@ export function startBrowserSdk(cfg = {}) {
         // and would skip replay in smoke tests.
         // @ts-ignore synthetics injects this global when present
         const isSynthetic = globalThis.syntheticsRunId != null;
-
-        sessionId = initSession();
 
         if (!isSynthetic) {
             // Dedicated provider avoids array-valued resource attrs (e.g. browser.brands)
@@ -330,7 +332,7 @@ export function startBrowserSdk(cfg = {}) {
 
     return {
         get sessionId() {
-            return sessionId ?? getSessionId();
+            return sessionId;
         },
         pauseReplay,
         resumeReplay,

--- a/packages/opentelemetry-browser/lib/sdk.js
+++ b/packages/opentelemetry-browser/lib/sdk.js
@@ -30,6 +30,7 @@ import {
     TraceIdRatioBasedSampler,
     TracerProvider,
 } from '@opentelemetry/sdk-trace';
+import {resourceFromAttributes} from '@opentelemetry/resources';
 
 import {registerInstrumentations} from '@opentelemetry/instrumentation';
 import {BrowserNavigationInstrumentation} from '@opentelemetry/instrumentation-browser-navigation';
@@ -44,6 +45,18 @@ import {WebVitalsInstrumentation} from '@opentelemetry/browser-instrumentation/e
 import {AsyncApisContextManager} from './context.js';
 import {createLogger} from './logging.js';
 import {detectResource} from './detector.js';
+import {
+    checkRotation,
+    closeSession,
+    getSessionId,
+    initSession,
+} from './session.js';
+import {
+    pauseReplay,
+    resumeReplay,
+    startReplay,
+    stopReplay,
+} from './replay.js';
 
 /**
  * @typedef {{
@@ -71,6 +84,40 @@ import {detectResource} from './detector.js';
  *
  * // other options
  * @property {Partial<InstrumentationsConfigMap>} [instrumentations]
+ *
+ * // experimental session replay (POC)
+ * @property {ReplayConfiguration} [replay]
+ */
+
+/**
+ * @typedef {Object} ReplayPrivacyConfiguration
+ * @property {boolean} [maskAllInputs]
+ * @property {boolean} [maskAllText]
+ * @property {string} [maskTextSelector]
+ * @property {string} [blockSelector]
+ * @property {string} [blockClass]
+ * @property {string} [ignoreClass]
+ * @property {Record<string, boolean>} [maskInputOptions]
+ * @property {(text: string, element: HTMLElement) => string} [maskInputFn]
+ */
+
+/**
+ * @typedef {Object} ReplayQualityConfiguration
+ * @property {boolean} [inlineStylesheet]
+ * @property {boolean} [collectFonts]
+ * @property {boolean} [slimDOM]
+ * @property {boolean} [recordCanvas]
+ * @property {boolean} [packEvents]
+ */
+
+/**
+ * Experimental session replay options (POC). Off by default.
+ * @typedef {Object} ReplayConfiguration
+ * @property {boolean} [enabled]
+ * @property {number} [samplingRate] // 0-100, default 100
+ * @property {number} [errorSamplingRate] // 0-100, default 100; >0 enables error backfill
+ * @property {ReplayPrivacyConfiguration} [privacy]
+ * @property {ReplayQualityConfiguration} [quality]
  */
 
 // To control multiple calls to `startBrowserSdk`
@@ -89,8 +136,12 @@ const defaultConfig = {
 /**
  * @param {BrowserSdkConfiguration} cfg
  * @returns {{
- *      forceFlush: () => Promise<void>
- * }}
+ *      forceFlush: () => Promise<void>,
+ *      shutdown: () => Promise<void>,
+ *      pauseReplay: () => void,
+ *      resumeReplay: () => void,
+ *      sessionId: string | null,
+ * } | undefined}
  */
 export function startBrowserSdk(cfg = {}) {
     if (sdkStarted || cfg.disabled) {
@@ -223,16 +274,130 @@ export function startBrowserSdk(cfg = {}) {
     }
     registerInstrumentations({instrumentations: enabledInstrumentations});
 
+    const replayCfg = resolveReplayConfig(config.replay);
+    /** @type {import('@opentelemetry/sdk-logs').LoggerProvider | null} */
+    let replayLoggerProvider = null;
+    /** @type {Promise<void>} */
+    let replayReady = Promise.resolve();
+    /** @type {string | null} */
+    let sessionId = null;
+
+    if (replayCfg.enabled) {
+        // Elastic Synthetics injects syntheticsRunId. Do not use
+        // navigator.webdriver — Playwright (and other automation) sets it
+        // and would skip replay in smoke tests.
+        // @ts-ignore synthetics injects this global when present
+        const isSynthetic = globalThis.syntheticsRunId != null;
+
+        sessionId = initSession();
+
+        if (!isSynthetic) {
+            // Dedicated provider avoids array-valued resource attrs (e.g. browser.brands)
+            // that have historically broken large FullSnapshot log exports.
+            const logsEndpoint = appendPath(endpointUrl, 'v1/logs').href;
+            replayLoggerProvider = new LoggerProvider({
+                resource: resourceFromAttributes({
+                    'service.name': config.serviceName ?? defaultConfig.serviceName,
+                    'session.id': sessionId,
+                    'rum.sessionId': sessionId,
+                    'telemetry.distro.name': 'elastic',
+                }),
+                processors: [
+                    new BatchLogRecordProcessor({
+                        exporter: new OTLPLogExporter({
+                            url: logsEndpoint,
+                            headers: config.exportHeaders,
+                        }),
+                    }),
+                ],
+            });
+            const replayLogger = replayLoggerProvider.getLogger('elastic-rrweb');
+            replayReady = startReplay({
+                samplingRate: replayCfg.samplingRate,
+                errorSamplingRate: replayCfg.errorSamplingRate,
+                replayLogger,
+                getSessionId,
+                checkRotation,
+                privacy: replayCfg.privacy,
+                quality: replayCfg.quality,
+            }).catch((err) => {
+                diag.warn('startReplay failed; replay disabled', err);
+            });
+        } else {
+            diag.debug('Replay skipped for synthetic monitor');
+        }
+    }
+
     // Flag as started
     sdkStarted = true;
 
     return {
+        get sessionId() {
+            return sessionId ?? getSessionId();
+        },
+        pauseReplay,
+        resumeReplay,
         forceFlush() {
-            return Promise.all([
+            return replayReady.then(() =>
+                Promise.all([
+                    tracerProvider.forceFlush(),
+                    meterProvider.forceFlush(),
+                    loggerProvider.forceFlush(),
+                    replayLoggerProvider?.forceFlush() ?? Promise.resolve(),
+                ]).then(() => {})
+            );
+        },
+        async shutdown() {
+            await replayReady;
+            stopReplay();
+            closeSession();
+            await Promise.all([
                 tracerProvider.forceFlush(),
                 meterProvider.forceFlush(),
                 loggerProvider.forceFlush(),
-            ]).then(() => {});
+                replayLoggerProvider?.forceFlush() ?? Promise.resolve(),
+            ]);
+            try {
+                await replayLoggerProvider?.shutdown();
+            } catch (err) {
+                diag.warn('replay LoggerProvider shutdown failed', err);
+            }
+            sdkStarted = false;
+        },
+    };
+}
+
+/**
+ * @param {ReplayConfiguration | undefined} replay
+ * @returns {{
+ *   enabled: boolean,
+ *   samplingRate: number,
+ *   errorSamplingRate: number,
+ *   privacy: Required<Pick<ReplayPrivacyConfiguration, 'maskAllInputs' | 'maskAllText' | 'blockClass' | 'ignoreClass'>> & ReplayPrivacyConfiguration,
+ *   quality: Required<Pick<ReplayQualityConfiguration, 'inlineStylesheet' | 'collectFonts' | 'slimDOM' | 'recordCanvas' | 'packEvents'>>,
+ * }}
+ */
+function resolveReplayConfig(replay) {
+    return {
+        enabled: replay?.enabled === true,
+        samplingRate: replay?.samplingRate ?? 100,
+        errorSamplingRate: replay?.errorSamplingRate ?? 100,
+        privacy: {
+            maskAllInputs: replay?.privacy?.maskAllInputs ?? true,
+            maskAllText: replay?.privacy?.maskAllText ?? false,
+            maskTextSelector: replay?.privacy?.maskTextSelector,
+            blockSelector: replay?.privacy?.blockSelector,
+            blockClass: replay?.privacy?.blockClass ?? 'rum-block',
+            ignoreClass: replay?.privacy?.ignoreClass ?? 'rum-ignore',
+            maskInputOptions: replay?.privacy?.maskInputOptions,
+            maskInputFn: replay?.privacy?.maskInputFn,
+        },
+        quality: {
+            inlineStylesheet: replay?.quality?.inlineStylesheet ?? true,
+            collectFonts: replay?.quality?.collectFonts ?? false,
+            slimDOM: replay?.quality?.slimDOM ?? true,
+            recordCanvas: replay?.quality?.recordCanvas ?? false,
+            packEvents: replay?.quality?.packEvents ?? false,
         },
     };
 }

--- a/packages/opentelemetry-browser/lib/sdk.js
+++ b/packages/opentelemetry-browser/lib/sdk.js
@@ -51,12 +51,7 @@ import {
     getSessionId,
     initSession,
 } from './session.js';
-import {
-    pauseReplay,
-    resumeReplay,
-    startReplay,
-    stopReplay,
-} from './replay.js';
+import {pauseReplay, resumeReplay, startReplay, stopReplay} from './replay.js';
 
 /**
  * @typedef {{
@@ -297,7 +292,8 @@ export function startBrowserSdk(cfg = {}) {
             const logsEndpoint = appendPath(endpointUrl, 'v1/logs').href;
             replayLoggerProvider = new LoggerProvider({
                 resource: resourceFromAttributes({
-                    'service.name': config.serviceName ?? defaultConfig.serviceName,
+                    'service.name':
+                        config.serviceName ?? defaultConfig.serviceName,
                     'session.id': sessionId,
                     'rum.sessionId': sessionId,
                     'telemetry.distro.name': 'elastic',
@@ -311,7 +307,8 @@ export function startBrowserSdk(cfg = {}) {
                     }),
                 ],
             });
-            const replayLogger = replayLoggerProvider.getLogger('elastic-rrweb');
+            const replayLogger =
+                replayLoggerProvider.getLogger('elastic-rrweb');
             replayReady = startReplay({
                 samplingRate: replayCfg.samplingRate,
                 errorSamplingRate: replayCfg.errorSamplingRate,

--- a/packages/opentelemetry-browser/lib/session.js
+++ b/packages/opentelemetry-browser/lib/session.js
@@ -43,7 +43,10 @@ export function initSession(cfg = {}) {
         }
     };
     for (const ev of ['click', 'keydown', 'scroll', 'touchstart']) {
-        window.addEventListener(ev, _onActivity, {passive: true, capture: true});
+        window.addEventListener(ev, _onActivity, {
+            passive: true,
+            capture: true,
+        });
     }
 
     try {

--- a/packages/opentelemetry-browser/lib/session.js
+++ b/packages/opentelemetry-browser/lib/session.js
@@ -1,0 +1,186 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {diag} from '@opentelemetry/api';
+
+const SESSION_KEY = 'elastic.rum.sid';
+const CHANNEL_NAME = 'elastic-rum-session';
+const DEFAULT_MAX_MS = 14 * 60 * 1000; // 14 min
+const DEFAULT_IDLE_MS = 30 * 60 * 1000; // 30 min
+
+let _id = null;
+let _startedAt = 0;
+let _lastActivity = Date.now();
+let _channel = null;
+let _persistSession = false;
+/** @type {(() => void) | null} */
+let _onActivity = null;
+
+/**
+ * @param {{maxMs?: number, idleMs?: number, persistSession?: boolean}} [cfg]
+ * @returns {string} session ID
+ */
+export function initSession(cfg = {}) {
+    if (_id) {
+        return _id;
+    }
+
+    _persistSession = cfg.persistSession === true;
+
+    const stored = _persistSession ? _readCookie() : _readStorage();
+    _id = stored || _generateUUID();
+    _startedAt = Date.now();
+    _lastActivity = Date.now();
+
+    _writeSession(_id);
+
+    _onActivity = () => {
+        _lastActivity = Date.now();
+        if (_persistSession) {
+            _writeCookie(_id);
+        }
+    };
+    for (const ev of ['click', 'keydown', 'scroll', 'touchstart']) {
+        window.addEventListener(ev, _onActivity, {passive: true, capture: true});
+    }
+
+    try {
+        _channel = new BroadcastChannel(CHANNEL_NAME);
+        _channel.onmessage = (e) => {
+            if (e.data && e.data.type === 'rotate') {
+                _id = e.data.id;
+                _startedAt = Date.now();
+                _lastActivity = Date.now();
+                _writeSession(_id);
+            }
+        };
+    } catch (err) {
+        diag.debug('BroadcastChannel not available', err);
+    }
+
+    return _id;
+}
+
+/** @returns {string | null} */
+export function getSessionId() {
+    return _id;
+}
+
+/**
+ * @param {{maxMs?: number, idleMs?: number}} [cfg]
+ * @param {(newId: string) => void} [onRotateFn]
+ * @returns {boolean} whether rotation occurred
+ */
+export function checkRotation(cfg = {}, onRotateFn) {
+    const maxMs = cfg.maxMs ?? DEFAULT_MAX_MS;
+    const idleMs = cfg.idleMs ?? DEFAULT_IDLE_MS;
+    const now = Date.now();
+    const elapsed = now - _startedAt;
+    const idle = now - _lastActivity;
+
+    if (elapsed < maxMs && idle < idleMs) {
+        return false;
+    }
+
+    const newId = _generateUUID();
+    _id = newId;
+    _startedAt = now;
+    _lastActivity = now;
+    _writeSession(newId);
+
+    try {
+        _channel && _channel.postMessage({type: 'rotate', id: newId});
+    } catch (_) {}
+
+    if (typeof onRotateFn === 'function') {
+        onRotateFn(newId);
+    }
+
+    diag.debug('Session rotated', newId);
+    return true;
+}
+
+/**
+ * Closes the BroadcastChannel, removes activity listeners, and resets module state.
+ */
+export function closeSession() {
+    if (_onActivity) {
+        for (const ev of ['click', 'keydown', 'scroll', 'touchstart']) {
+            try {
+                window.removeEventListener(ev, _onActivity, {
+                    capture: true,
+                });
+            } catch (_) {}
+        }
+        _onActivity = null;
+    }
+    if (_channel) {
+        try {
+            _channel.close();
+        } catch (_) {}
+        _channel = null;
+    }
+    _id = null;
+    _startedAt = 0;
+    _lastActivity = 0;
+    _persistSession = false;
+}
+
+// -- helper functions
+
+function _writeSession(id) {
+    if (_persistSession) {
+        _writeCookie(id);
+    } else {
+        _writeStorage(id);
+    }
+}
+
+function _readStorage() {
+    try {
+        return sessionStorage.getItem(SESSION_KEY) || null;
+    } catch (_) {
+        return null;
+    }
+}
+
+function _writeStorage(id) {
+    try {
+        sessionStorage.setItem(SESSION_KEY, id);
+    } catch (_) {}
+}
+
+function _readCookie() {
+    try {
+        const match = document.cookie
+            .split('; ')
+            .find((row) => row.startsWith(SESSION_KEY + '='));
+        return match ? decodeURIComponent(match.split('=')[1]) : null;
+    } catch (_) {
+        return null;
+    }
+}
+
+function _writeCookie(id) {
+    try {
+        const maxAge = Math.floor(DEFAULT_IDLE_MS / 1000);
+        const secure = location.protocol === 'https:' ? '; Secure' : '';
+        document.cookie = `${SESSION_KEY}=${encodeURIComponent(id)}; max-age=${maxAge}; SameSite=Strict; path=/${secure}`;
+    } catch (_) {}
+}
+
+function _generateUUID() {
+    if (
+        typeof crypto !== 'undefined' &&
+        typeof crypto.randomUUID === 'function'
+    ) {
+        return crypto.randomUUID();
+    }
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+        const r = (Math.random() * 16) | 0;
+        const v = c === 'x' ? r : (r & 0x3) | 0x8;
+        return v.toString(16);
+    });
+}

--- a/packages/opentelemetry-browser/package-lock.json
+++ b/packages/opentelemetry-browser/package-lock.json
@@ -27,7 +27,8 @@
         "@opentelemetry/resources": "^2.2.0",
         "@opentelemetry/sdk-logs": "^0.221.0",
         "@opentelemetry/sdk-metrics": "^2.2.0",
-        "@opentelemetry/sdk-trace": "^2.10.0"
+        "@opentelemetry/sdk-trace": "^2.10.0",
+        "@rrweb/record": "^2.1.1"
       },
       "devDependencies": {
         "@playwright/test": "^1.57.0",
@@ -884,6 +885,41 @@
         "node": ">=18"
       }
     },
+    "node_modules/@rrweb/record": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@rrweb/record/-/record-2.1.1.tgz",
+      "integrity": "sha512-c2u175R+daC37PhbjaQV0migxtIXsLuD0mRgRstj/x/CRmLGctRlDi373/4miIUclleq4eZIQXAglH9opclFRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rrweb/types": "^2.1.1",
+        "@rrweb/utils": "^2.1.1",
+        "rrweb": "^2.1.1"
+      }
+    },
+    "node_modules/@rrweb/types": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@rrweb/types/-/types-2.1.1.tgz",
+      "integrity": "sha512-g0I3nCNL1S7slDXwhunxOuOoswkY8WVZJQrPFiwixOc6xoD514d1JLTuyAzCKIox8g/PaLKtV5g31Uk42inQSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@rrweb/utils": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@rrweb/utils/-/utils-2.1.1.tgz",
+      "integrity": "sha512-x2SgJAD3YJ9eVcLZ5l6OqWMtczdA3VfS5XqPeqpZdQgV9oh6Id5GK2cDN4bimnkqryOcIJdz8cTvV0yNvqQ+nA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/css-font-loading-module": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.7.tgz",
+      "integrity": "sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==",
+      "license": "MIT"
+    },
+    "node_modules/@xstate/fsm": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@xstate/fsm/-/fsm-1.6.5.tgz",
+      "integrity": "sha512-b5o1I6aLNeYlU/3CPlj/Z91ybk1gUsKT+5NAJI+2W4UjvS5KLG28K9v5UvNoFVjHV8PajVZ00RH3vnjyQO7ZAw==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -903,6 +939,15 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^8"
+      }
+    },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/cjs-module-lexer": {
@@ -998,6 +1043,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
     "node_modules/module-details-from-path": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
@@ -1007,6 +1058,30 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
     },
     "node_modules/playwright": {
       "version": "1.57.0",
@@ -1040,6 +1115,34 @@
         "node": ">=18"
       }
     },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
     "node_modules/require-in-the-middle": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
@@ -1050,6 +1153,49 @@
       },
       "engines": {
         "node": ">=9.3.0 || >=8.10.0 <9.0.0"
+      }
+    },
+    "node_modules/rrdom": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/rrdom/-/rrdom-2.1.1.tgz",
+      "integrity": "sha512-VBkTF3bGNqcZjqnbo/gKi9GVQPIxiG0dofw7CQdAZQFQ2juJdt2YKIf3oS9QudL8HTpGh9bz5TUN+3amBn1Geg==",
+      "license": "MIT",
+      "dependencies": {
+        "rrweb-snapshot": "^2.1.1"
+      }
+    },
+    "node_modules/rrweb": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/rrweb/-/rrweb-2.1.1.tgz",
+      "integrity": "sha512-ToxhJg3SsrAhw+/DPhI/2iiwZQIrGK5BGkZ0kHn4qUExcvQYRaolkciD1FWX2+r6vf1IxFyhsoRY18h3D+XoCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rrweb/types": "^2.1.1",
+        "@rrweb/utils": "^2.1.1",
+        "@types/css-font-loading-module": "0.0.7",
+        "@xstate/fsm": "^1.4.0",
+        "base64-arraybuffer": "^1.0.1",
+        "mitt": "^3.0.0",
+        "rrdom": "^2.1.1",
+        "rrweb-snapshot": "^2.1.1"
+      }
+    },
+    "node_modules/rrweb-snapshot": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/rrweb-snapshot/-/rrweb-snapshot-2.1.1.tgz",
+      "integrity": "sha512-al4Kx7Am7YlIn/5Yb2EMr7cdmjGiK+cLhdilJEXqkFXgpnys8t/yMJumXy2Ormgirpg3MBnFha0GTgny+iIL2w==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss": "^8.4.38"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/web-vitals": {

--- a/packages/opentelemetry-browser/package.json
+++ b/packages/opentelemetry-browser/package.json
@@ -39,9 +39,10 @@
     "prepublishOnly": "npm run build",
     "clean": "rm -rf build",
     "build:version": "CODE=\"export const EDOT_VERSION = '$(npx json -f package.json version)';\"; awk -v code=\"$CODE\" '/^export/ { print code; next } { print }' lib/version.js > tmp && mv tmp lib/version.js",
-    "build:iife": "esbuild ./lib/bundle.js --bundle --conditions=esnext,module --sourcemap --platform=browser --target=es2022 --outfile=build/elastic-otel-browser.js",
-    "build:min": "esbuild ./lib/bundle.js --bundle --conditions=esnext,module --minify --sourcemap --platform=browser --target=es2022 --outfile=build/elastic-otel-browser.min.js",
-    "build": "npm run clean && npm run build:version && npm run build:iife && npm run build:min",
+    "build:iife": "esbuild ./lib/bundle.js --bundle --conditions=esnext,module --sourcemap --platform=browser --target=es2022 --external:@rrweb/record --outfile=build/elastic-otel-browser.js",
+    "build:min": "esbuild ./lib/bundle.js --bundle --conditions=esnext,module --minify --sourcemap --platform=browser --target=es2022 --external:@rrweb/record --outfile=build/elastic-otel-browser.min.js",
+    "build:min:replay": "esbuild ./lib/bundle.js --bundle --conditions=esnext,module --minify --sourcemap --platform=browser --target=es2022 --outfile=build/elastic-otel-browser-replay.min.js",
+    "build": "npm run clean && npm run build:version && npm run build:iife && npm run build:min && npm run build:min:replay",
     "gen:types": "rm -rf types && tsc # TODO: would be nice to tree-shake the *.d.ts files",
     "lint": "npm run lint:eslint && npm run lint:prettier && npm run lint:licenses && npm run lint:version && npm run lint:types",
     "lint:eslint": "eslint .",
@@ -74,7 +75,8 @@
     "@opentelemetry/resources": "^2.2.0",
     "@opentelemetry/sdk-logs": "^0.221.0",
     "@opentelemetry/sdk-metrics": "^2.2.0",
-    "@opentelemetry/sdk-trace": "^2.10.0"
+    "@opentelemetry/sdk-trace": "^2.10.0",
+    "@rrweb/record": "^2.1.1"
   },
   "devDependencies": {
     "@playwright/test": "^1.57.0",

--- a/packages/opentelemetry-browser/test/smoke/config-replay.spec.js
+++ b/packages/opentelemetry-browser/test/smoke/config-replay.spec.js
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {test, expect} from '@playwright/test';
+import {createCollector} from './test-utils.js';
+
+test('replay.samplingRate:0 and errorSamplingRate:0 emits no elastic-rrweb logs', async ({
+    page,
+}) => {
+    const collector = createCollector(page);
+    const config = encodeURIComponent(
+        JSON.stringify({
+            serviceName: 'replay-smoke',
+            otlpEndpoint: 'http://localhost:3000',
+            replay: {
+                enabled: true,
+                samplingRate: 0,
+                errorSamplingRate: 0,
+            },
+        })
+    );
+    await page.goto(`/fixtures/use-replay.html?config=${config}&sync=true`);
+    await page.click('#action');
+    await page.waitForTimeout(500);
+
+    let logs = [];
+    try {
+        logs = await collector.getLogs({flush: true});
+    } catch (_) {
+        // no logs at all is fine
+    }
+    const replayLogs = logs.filter((l) => l.scope?.name === 'elastic-rrweb');
+    expect(replayLogs.length).toBe(0);
+});
+
+test('replay.enabled:false does not load replay path', async ({page}) => {
+    const collector = createCollector(page);
+    const config = encodeURIComponent(
+        JSON.stringify({
+            serviceName: 'replay-smoke',
+            otlpEndpoint: 'http://localhost:3000',
+            replay: {enabled: false},
+        })
+    );
+    await page.goto(`/fixtures/use-replay.html?config=${config}&sync=true`);
+    await page.click('#action');
+    await page.waitForTimeout(300);
+
+    // Traces still work
+    const spans = await collector.getSpans({flush: true});
+    expect(spans.length).toBeGreaterThan(0);
+
+    const logs = collector.getRequests().filter((r) => r.url.includes('/v1/logs'));
+    // May have web-vitals/exception logs; assert no elastic-rrweb scope
+    let replayCount = 0;
+    for (const req of logs) {
+        for (const rl of req.data.resourceLogs || []) {
+            for (const sl of rl.scopeLogs || []) {
+                if (sl.scope?.name === 'elastic-rrweb') {
+                    replayCount += (sl.logRecords || []).length;
+                }
+            }
+        }
+    }
+    expect(replayCount).toBe(0);
+});

--- a/packages/opentelemetry-browser/test/smoke/config-replay.spec.js
+++ b/packages/opentelemetry-browser/test/smoke/config-replay.spec.js
@@ -52,7 +52,9 @@ test('replay.enabled:false does not load replay path', async ({page}) => {
     const spans = await collector.getSpans({flush: true});
     expect(spans.length).toBeGreaterThan(0);
 
-    const logs = collector.getRequests().filter((r) => r.url.includes('/v1/logs'));
+    const logs = collector
+        .getRequests()
+        .filter((r) => r.url.includes('/v1/logs'));
     // May have web-vitals/exception logs; assert no elastic-rrweb scope
     let replayCount = 0;
     for (const req of logs) {

--- a/packages/opentelemetry-browser/test/smoke/fixtures/use-replay.html
+++ b/packages/opentelemetry-browser/test/smoke/fixtures/use-replay.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <title>Session Replay Test</title>
+        <!-- EDOT_PLACEHOLDER (DO NOT REMOVE)-->
+    </head>
+    <body>
+        <h1>Session Replay Test</h1>
+        <button id="action">Click me</button>
+    </body>
+</html>

--- a/packages/opentelemetry-browser/test/smoke/replay.spec.js
+++ b/packages/opentelemetry-browser/test/smoke/replay.spec.js
@@ -21,9 +21,7 @@ test('replay.enabled emits elastic-rrweb logs with required attributes', async (
             },
         })
     );
-    await page.goto(
-        `/fixtures/use-replay.html?config=${config}&sync=true`
-    );
+    await page.goto(`/fixtures/use-replay.html?config=${config}&sync=true`);
     await page.click('#action');
     // Allow async startReplay (dynamic import / record init) to finish
     await page.waitForTimeout(1000);

--- a/packages/opentelemetry-browser/test/smoke/replay.spec.js
+++ b/packages/opentelemetry-browser/test/smoke/replay.spec.js
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {test, expect} from '@playwright/test';
+import {createCollector} from './test-utils.js';
+
+test('replay.enabled emits elastic-rrweb logs with required attributes', async ({
+    page,
+}) => {
+    const collector = createCollector(page);
+    const config = encodeURIComponent(
+        JSON.stringify({
+            serviceName: 'replay-smoke',
+            otlpEndpoint: 'http://localhost:3000',
+            replay: {
+                enabled: true,
+                samplingRate: 100,
+                errorSamplingRate: 100,
+            },
+        })
+    );
+    await page.goto(
+        `/fixtures/use-replay.html?config=${config}&sync=true`
+    );
+    await page.click('#action');
+    // Allow async startReplay (dynamic import / record init) to finish
+    await page.waitForTimeout(1000);
+
+    const logs = await collector.getLogs({flush: true});
+    const replayLogs = logs.filter((l) => l.scope?.name === 'elastic-rrweb');
+    expect(replayLogs.length).toBeGreaterThan(0);
+
+    const sample = replayLogs.find((l) => l.attributes?.['session.id']);
+    expect(sample).toBeTruthy();
+    expect(sample.attributes['session.id']).toBeTruthy();
+    expect(
+        sample.attributes['rr-web.event'] === 0 ||
+            sample.attributes['rr-web.event'] > 0
+    ).toBeTruthy();
+    expect(sample.attributes['rrweb.type']).toBeDefined();
+    expect(sample.attributes['elastic.rum.log.type']).toBe('replay');
+});

--- a/packages/opentelemetry-browser/test/smoke/replay.spec.js
+++ b/packages/opentelemetry-browser/test/smoke/replay.spec.js
@@ -40,3 +40,52 @@ test('replay.enabled emits elastic-rrweb logs with required attributes', async (
     expect(sample.attributes['rrweb.type']).toBeDefined();
     expect(sample.attributes['elastic.rum.log.type']).toBe('replay');
 });
+
+test('rr-web.event stays unique and monotonic across full page reloads', async ({
+    page,
+}) => {
+    const collector = createCollector(page);
+    const config = encodeURIComponent(
+        JSON.stringify({
+            serviceName: 'replay-smoke',
+            otlpEndpoint: 'http://localhost:3000',
+            replay: {
+                enabled: true,
+                samplingRate: 100,
+                errorSamplingRate: 100,
+            },
+        })
+    );
+
+    const eventIndices = async () => {
+        const logs = await collector.getLogs({flush: true});
+        return logs
+            .filter((l) => l.scope?.name === 'elastic-rrweb')
+            .map((l) => l.attributes?.['rr-web.event'])
+            .filter((n) => typeof n === 'number');
+    };
+
+    // First page load.
+    await page.goto(`/fixtures/use-replay.html?config=${config}&sync=true`);
+    await page.click('#action');
+    await page.waitForTimeout(1000);
+    const first = await eventIndices();
+    expect(first.length).toBeGreaterThan(0);
+    const firstMax = Math.max(...first);
+
+    collector.clear();
+
+    // Full navigation (new document). Same tab keeps session.id + sequence in
+    // sessionStorage, so the counter must continue rather than restart at 0.
+    await page.goto(`/fixtures/use-replay.html?config=${config}&sync=true`);
+    await page.click('#action');
+    await page.waitForTimeout(1000);
+    const second = await eventIndices();
+    expect(second.length).toBeGreaterThan(0);
+
+    // Continued past the previous page (regression: it used to restart at 0).
+    expect(Math.min(...second)).toBeGreaterThan(firstMax);
+    // No index is reused across the two page loads.
+    const firstSet = new Set(first);
+    expect(second.filter((n) => firstSet.has(n))).toEqual([]);
+});

--- a/packages/opentelemetry-browser/test/smoke/server.js
+++ b/packages/opentelemetry-browser/test/smoke/server.js
@@ -93,20 +93,24 @@ console.log(`server listening to http://localhost:${server.address().port}`);
 
 function injectSdk(html, config, jsSync) {
     const placeholder = '<!-- EDOT_PLACEHOLDER (DO NOT REMOVE)-->';
+    const replayEnabled = config?.replay?.enabled === true;
+    const bundle = replayEnabled
+        ? '/assets/elastic-otel-browser-replay.min.js'
+        : '/assets/elastic-otel-browser.min.js';
     const codeAsync = `
         <script>
         // Same pattern as https://www.elastic.co/docs/reference/apm/agents/rum-js/install-agent#_asynchronous_non_blocking_pattern
         ;(function(d, s, c) {
             var j = d.createElement(s),
                 t = d.getElementsByTagName(s)[0];
-            j.src = '/assets/elastic-otel-browser.min.js';
+            j.src = '${bundle}';
             j.onload = function() { globalThis.edotBrowser = startBrowserSdk(c); };
             t.parentNode.insertBefore(j, t);
         })(document, 'script', ${JSON.stringify(config)})
         </script>
     `;
     const codeSync = `
-        <script src="/assets/elastic-otel-browser.min.js"></script>
+        <script src="${bundle}"></script>
         <script>
             globalThis.edotBrowser = startBrowserSdk(${JSON.stringify(config)});
         </script>

--- a/packages/opentelemetry-browser/test/unit/session.spec.js
+++ b/packages/opentelemetry-browser/test/unit/session.spec.js
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'node:assert';
+import {afterEach, beforeEach, test} from 'node:test';
+
+import {
+    checkRotation,
+    closeSession,
+    getSessionId,
+    initSession,
+} from '../../lib/session.js';
+
+function installBrowserMocks() {
+    const store = new Map();
+    globalThis.sessionStorage = {
+        getItem: (k) => (store.has(k) ? store.get(k) : null),
+        setItem: (k, v) => store.set(k, String(v)),
+        removeItem: (k) => store.delete(k),
+        clear: () => store.clear(),
+    };
+    globalThis.window = {
+        addEventListener() {},
+        removeEventListener() {},
+    };
+    globalThis.document = {cookie: ''};
+    globalThis.location = {protocol: 'http:'};
+    globalThis.BroadcastChannel = class {
+        postMessage() {}
+        close() {}
+        set onmessage(_fn) {}
+    };
+    return store;
+}
+
+beforeEach(() => {
+    closeSession();
+    installBrowserMocks();
+});
+
+afterEach(() => {
+    closeSession();
+});
+
+test('initSession returns a UUID-shaped id and getSessionId matches', () => {
+    const id = initSession();
+    assert.equal(typeof id, 'string');
+    assert.match(
+        id,
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+    );
+    assert.equal(getSessionId(), id);
+});
+
+test('initSession is idempotent', () => {
+    const a = initSession();
+    const b = initSession();
+    assert.equal(a, b);
+});
+
+test('initSession reuses sessionStorage value', () => {
+    sessionStorage.setItem('elastic.rum.sid', 'stored-session-id');
+    const id = initSession();
+    assert.equal(id, 'stored-session-id');
+});
+
+test('checkRotation returns false when within max and idle windows', () => {
+    initSession();
+    const rotated = checkRotation({maxMs: 60_000, idleMs: 60_000});
+    assert.equal(rotated, false);
+    assert.ok(getSessionId());
+});
+
+test('checkRotation rotates when maxMs exceeded', () => {
+    const id = initSession();
+    // Force elapsed by calling with maxMs: 0
+    const rotated = checkRotation({maxMs: 0, idleMs: 60_000});
+    assert.equal(rotated, true);
+    assert.notEqual(getSessionId(), id);
+});
+
+test('closeSession clears id', () => {
+    initSession();
+    closeSession();
+    assert.equal(getSessionId(), null);
+});

--- a/packages/opentelemetry-browser/types/replay.d.ts
+++ b/packages/opentelemetry-browser/types/replay.d.ts
@@ -1,0 +1,26 @@
+/**
+ * Starts rrweb recording (loads `@rrweb/record` dynamically).
+ *
+ * @param {{
+ *   samplingRate?: number,
+ *   errorSamplingRate?: number,
+ *   replayLogger: import('@opentelemetry/api-logs').Logger,
+ *   getSessionId: () => string | null,
+ *   checkRotation: (cfg?: any, fn?: Function) => boolean,
+ *   privacy?: object,
+ *   quality?: object,
+ * }} cfg
+ * @returns {Promise<void>}
+ */
+export function startReplay(cfg: {
+    samplingRate?: number;
+    errorSamplingRate?: number;
+    replayLogger: import('@opentelemetry/api-logs').Logger;
+    getSessionId: () => string | null;
+    checkRotation: (cfg?: any, fn?: Function) => boolean;
+    privacy?: object;
+    quality?: object;
+}): Promise<void>;
+export function pauseReplay(): void;
+export function resumeReplay(): void;
+export function stopReplay(): void;

--- a/packages/opentelemetry-browser/types/sdk.d.ts
+++ b/packages/opentelemetry-browser/types/sdk.d.ts
@@ -14,7 +14,7 @@ export function startBrowserSdk(cfg?: BrowserSdkConfiguration): {
     pauseReplay: () => void;
     resumeReplay: () => void;
     sessionId: string | null;
-} | undefined;
+};
 export type InstrumentationsConfigMap = {
     "@opentelemetry/instrumentation-browser-navigation": import('@opentelemetry/instrumentation-browser-navigation').BrowserNavigationInstrumentationConfig;
     "@opentelemetry/instrumentation-document-load": import('@opentelemetry/instrumentation-document-load').DocumentLoadInstrumentationConfig;
@@ -33,11 +33,14 @@ export type BrowserSdkConfiguration = {
     sampleRate?: number;
     resourceAttributes?: Record<string, import('./detector.js').AttributeValue>;
     otlpEndpoint?: string;
-    exportHeaders?: Record<string, string>;
-    instrumentations?: Partial<InstrumentationsConfigMap>;
     /**
-     * Experimental session replay (POC). Off unless `enabled: true`.
+     * // other options
      */
+    exportHeaders?: Record<string, string>;
+    /**
+     * // experimental session replay (POC)
+     */
+    instrumentations?: Partial<InstrumentationsConfigMap>;
     replay?: ReplayConfiguration;
 };
 export type ReplayPrivacyConfiguration = {
@@ -62,14 +65,10 @@ export type ReplayQualityConfiguration = {
  */
 export type ReplayConfiguration = {
     enabled?: boolean;
-    /**
-     * 0-100, default 100
-     */
     samplingRate?: number;
-    /**
-     * 0-100, default 100; >0 enables error backfill
-     */
     errorSamplingRate?: number;
     privacy?: ReplayPrivacyConfiguration;
     quality?: ReplayQualityConfiguration;
 };
+import { pauseReplay } from './replay.js';
+import { resumeReplay } from './replay.js';

--- a/packages/opentelemetry-browser/types/sdk.d.ts
+++ b/packages/opentelemetry-browser/types/sdk.d.ts
@@ -1,12 +1,20 @@
 /**
  * @param {BrowserSdkConfiguration} cfg
  * @returns {{
- *      forceFlush: () => Promise<void>
- * }}
+ *      forceFlush: () => Promise<void>,
+ *      shutdown: () => Promise<void>,
+ *      pauseReplay: () => void,
+ *      resumeReplay: () => void,
+ *      sessionId: string | null,
+ * } | undefined}
  */
 export function startBrowserSdk(cfg?: BrowserSdkConfiguration): {
     forceFlush: () => Promise<void>;
-};
+    shutdown: () => Promise<void>;
+    pauseReplay: () => void;
+    resumeReplay: () => void;
+    sessionId: string | null;
+} | undefined;
 export type InstrumentationsConfigMap = {
     "@opentelemetry/instrumentation-browser-navigation": import('@opentelemetry/instrumentation-browser-navigation').BrowserNavigationInstrumentationConfig;
     "@opentelemetry/instrumentation-document-load": import('@opentelemetry/instrumentation-document-load').DocumentLoadInstrumentationConfig;
@@ -25,9 +33,43 @@ export type BrowserSdkConfiguration = {
     sampleRate?: number;
     resourceAttributes?: Record<string, import('./detector.js').AttributeValue>;
     otlpEndpoint?: string;
-    /**
-     * // other options
-     */
     exportHeaders?: Record<string, string>;
     instrumentations?: Partial<InstrumentationsConfigMap>;
+    /**
+     * Experimental session replay (POC). Off unless `enabled: true`.
+     */
+    replay?: ReplayConfiguration;
+};
+export type ReplayPrivacyConfiguration = {
+    maskAllInputs?: boolean;
+    maskAllText?: boolean;
+    maskTextSelector?: string;
+    blockSelector?: string;
+    blockClass?: string;
+    ignoreClass?: string;
+    maskInputOptions?: Record<string, boolean>;
+    maskInputFn?: (text: string, element: HTMLElement) => string;
+};
+export type ReplayQualityConfiguration = {
+    inlineStylesheet?: boolean;
+    collectFonts?: boolean;
+    slimDOM?: boolean;
+    recordCanvas?: boolean;
+    packEvents?: boolean;
+};
+/**
+ * Experimental session replay options (POC). Off by default.
+ */
+export type ReplayConfiguration = {
+    enabled?: boolean;
+    /**
+     * 0-100, default 100
+     */
+    samplingRate?: number;
+    /**
+     * 0-100, default 100; >0 enables error backfill
+     */
+    errorSamplingRate?: number;
+    privacy?: ReplayPrivacyConfiguration;
+    quality?: ReplayQualityConfiguration;
 };

--- a/packages/opentelemetry-browser/types/session.d.ts
+++ b/packages/opentelemetry-browser/types/session.d.ts
@@ -1,0 +1,24 @@
+/**
+ * @param {{maxMs?: number, idleMs?: number, persistSession?: boolean}} [cfg]
+ * @returns {string} session ID
+ */
+export function initSession(cfg?: {
+    maxMs?: number;
+    idleMs?: number;
+    persistSession?: boolean;
+}): string;
+/** @returns {string | null} */
+export function getSessionId(): string | null;
+/**
+ * @param {{maxMs?: number, idleMs?: number}} [cfg]
+ * @param {(newId: string) => void} [onRotateFn]
+ * @returns {boolean} whether rotation occurred
+ */
+export function checkRotation(cfg?: {
+    maxMs?: number;
+    idleMs?: number;
+}, onRotateFn?: (newId: string) => void): boolean;
+/**
+ * Closes the BroadcastChannel, removes activity listeners, and resets module state.
+ */
+export function closeSession(): void;

--- a/scripts/gen-notice.sh
+++ b/scripts/gen-notice.sh
@@ -85,6 +85,12 @@ npm ls --omit=dev --all --parseable \
         // do not include one in their install.
         const licFileFromPkgName = {
             "@opentelemetry/browser-instrumentation": "license.apache2.txt",
+            "@rrweb/record": "license.mit.txt",
+            "@rrweb/types": "license.mit.txt",
+            "@rrweb/utils": "license.mit.txt",
+            "rrweb": "license.mit.txt",
+            "rrweb-snapshot": "license.mit.txt",
+            "rrdom": "license.mit.txt",
         }
         // Packages that have a license, but no "license" entry in package.json.
         const licTypeFromPkgName = {

--- a/scripts/license.mit.txt
+++ b/scripts/license.mit.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Contributors (https://github.com/rrweb-io/rrweb/graphs/contributors)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary
- Experimental `replay` config on `startBrowserSdk` (off by default)
- Dynamic `@rrweb/record` → OTLP logs with scope `elastic-rrweb`
- Session module, smoke/unit tests, design and plan docs

## Test plan
- [ ] `cd packages/opentelemetry-browser && npm run test:unit`
- [ ] `npm run build && cp build/* ./test/smoke/assets && npx playwright test replay.spec.js config-replay.spec.js --project=chromium`
- [ ] Confirm default min bundle does not embed rrweb (external); replay min bundle does